### PR TITLE
Updated the 2016 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ computational effects.
 
 ### 2016
 
-* **Liberating effects with rows and handlers** (Draft, 2016)  
+* **Liberating effects with rows and handlers** (TyDe 2016)  
   by Daniel Hillerström and Sam Lindley  
-  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect-draft-march2016.pdf))
+  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
+
+* **Compiling Links Effect Handlers to the OCaml Backend** (ML Workshop 2016)  
+  by Daniel Hillerström, Sam Lindley and KC Sivaramakrishnan  
+  ([pdf](http://kcsrk.info/papers/links_ocaml_ml16.pdf))
 
 ### 2015
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,17 @@ computational effects.
 
 ### 2016
 
-* **Liberating effects with rows and handlers** (TyDe 2016)  
-  by Daniel Hillerström and Sam Lindley  
-  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
+* **Eff Directly in OCaml** (ML Workshop 2016)  
+  by Oleg Kiselyov and KC Sivaramakrishnan  
+  ([pdf](http://kcsrk.info/papers/eff_ocaml_ml16.pdf))
 
 * **Compiling Links Effect Handlers to the OCaml Backend** (ML Workshop 2016)  
   by Daniel Hillerström, Sam Lindley and KC Sivaramakrishnan  
   ([pdf](http://kcsrk.info/papers/links_ocaml_ml16.pdf))
+
+* **Liberating effects with rows and handlers** (TyDe 2016)  
+  by Daniel Hillerström and Sam Lindley  
+  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
 
 ### 2015
 


### PR DESCRIPTION
Hi Jeremy,

I updated the pdf link to the camera-ready version of our TyDe paper. Moreover I added references to the two extended abstracts about effect handlers appearing in ML Workshop this year.