### PR TITLE
Add TFP'17 paper, link to ML 2016 post-proceedings paper, and add OCaml effects abstract

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ computational effects.
 
 ### 2017
 
+* **Concurrent System Programming with Effect Handlers** (TFP 2017)  
+  by Stephen Dolan, Spiros Eliopolous, Daniel Hillerström, Anil Madhavapeddy, KC Sivaramakrishnan, Leo White  
+  ([pdf](http://kcsrk.info/papers/system_effects_feb_18.pdf))
+
 * **Handlers for Non-Monadic Computations** (IFL 2017)  
   by Ruben P. Pieters, Tom Schrijvers, and Exequiel Rivas  
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/ifl2017_post.pdf)) ([technical report/extended version](https://lirias.kuleuven.be/bitstream/123456789/617988/1/CW713.pdf))
@@ -123,7 +127,7 @@ computational effects.
 
 * **Eff Directly in OCaml** (ML Workshop 2016)  
   by Oleg Kiselyov and KC Sivaramakrishnan  
-  ([pdf](http://kcsrk.info/papers/eff_ocaml_ml16.pdf))
+  ([pdf](http://kcsrk.info/papers/caml-eff17.pdf)) ([extended abstract](http://kcsrk.info/papers/eff_ocaml_ml16.pdf))
 
 * **Compiling Links Effect Handlers to the OCaml Backend** (ML Workshop 2016)  
   by Daniel Hillerström, Sam Lindley, and KC Sivaramakrishnan  
@@ -133,13 +137,17 @@ computational effects.
   by Daniel Hillerström and Sam Lindley  
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
   ([dblp](http://dblp.uni-trier.de/rec/html/conf/icfp/HillerstromL16))
-  
+
 * **Dependent Types and Fibred Computational Effects** (FoSSaCS 2016)  
   by Danel Ahman, Neil Ghani, and Gordon Plotkin  
   ([pdf](https://danelahman.github.io/papers/fossacs16.pdf))
   ([dblp](http://dblp.org/rec/conf/fossacs/AhmanGP16))
 
 ### 2015
+
+* **Effective Concurrency with Algebraic Effects** (OCaml Workshop 2015)  
+  by Stephen Dolan, Leo White, KC Sivaramakrishnan, Jeremy Yallop and Anil Madhavapeddy  
+  ([pdf](http://kcsrk.info/papers/effects_ocaml15.pdf))
 
 * **Fixing Non-determinism** (IFL 2015)  
   by Alexander Vandenbroucke, Tom Schrijvers, and Frank Piessens  
@@ -155,18 +163,15 @@ computational effects.
   ([dblp](http://dblp.uni-trier.de/rec/html/journals/jlp/BauerP15))
   ([doi](http://dx.doi.org/10.1016/j.jlamp.2014.02.001))
 
-
 * **An Introduction to Algebraic Effects and Handlers** (MFPS 2015)  
   by Matija Pretnar  
   ([dblp](http://dblp.uni-trier.de/rec/html/journals/entcs/Pretnar15))
   ([doi](http://dx.doi.org/10.1016/j.entcs.2015.12.003))
   ([pdf](http://www.eff-lang.org/handlers-tutorial.pdf))
 
-
 * **Fusion for Free: Efficient Algebraic Effect Handlers** (MPC 2015)  
   by Nicolas Wu and Tom Schrijvers  
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf))
-
 
 * **Interleaving data and effects** (JFP 2015)  
   by Robert Atkey and Patricia Johann  
@@ -199,7 +204,6 @@ computational effects.
   ([arxiv](http://arxiv.org/pdf/1312.2334.pdf))
   ([dblp](http://dblp.uni-trier.de/rec/html/journals/corr/Pretnar13))
   ([doi](http://dx.doi.org/10.2168/LMCS-10%283:21%292014))
-
 
 * **An Effect System for Algebraic Effects and Handlers** (LMCS 2014)  
   by Andrej Bauer and Matija Pretnar  


### PR DESCRIPTION
I don't intend to make this a daily routine. But I realised the following references were missing:

- Concurrent System Programming with Effect Handlers (TFP'17)
- The full paper version of Eff Directly in OCaml (ML'16)
- The Multicore OCaml abstract about algebraic effects and handlers in OCaml (OCaml'15)