### PR TITLE
Fix broken links to papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ in various programming languages.
 
 * **Contextual Effect Polymorphism Meets Bidirectional Effects (Extended Abstract)** (TyDe 2021)  
   by Kazuki Niimi, Youyou Cong, and Jonathan Immanuel Brachthäuser  
-  ([pdf](https://researchmap.jp/youyoucong/presentations/32929533/attachment_file.pdf))
+  ([pdf](https://prg.is.titech.ac.jp/members/masuhara/papers/tyde2021.pdf))
 
 * **Formalising Algebraic Effects with Non-Recoverable Failure** (HOPE 2021)  
   by Timotej Tomandl and Dominic Orchard  

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Effects bibliography
 
-A collection of research papers and other resources related to the theory and practice of
-computational effects.
+A collection of research papers and other resources related to the theory and practice
+of computational effects.
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Effects bibliography
 
-A collection of research papers and other resources related to the theory and practice
-of computational effects.
+A collection of research papers and other resources related to the
+theory and practice of computational effects.
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ in various programming languages.
 
   * **Design and Implementation of Effect Handlers for Object-Oriented Programming Languages** (PhD Dissertation, University of Tübingen)  
     by Jonathan Immanuel Brachthäuser  
-    ([pdf](https://publikationen.uni-tuebingen.de/xmlui/bitstream/handle/10900/102021/thesis-v1.1.pdf?sequence=1&isAllowed=y))
+    ([dblp](https://dblp.uni-trier.de/rec/phd/dnb/Brachthauser20.html))
 
   ### 2019
 


### PR DESCRIPTION
- `Contextual Effect Polymorphism` was pointing to `First-class Named Handlers`
- `Design and Implementation of Effect Handlers for Object-Oriented Programming Languages` had broken link so I've changed that to dblp entry