### PR TITLE
Fix spelling error in author name

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ in various programming languages.
 ### 2023
 
 * **Hefty Algebras: Modular Elaboration of Higher-Order Algebraic Effects** (POPL 2023)  
-  by Caspar Bach Poulsen and Cas Van Der Rest  
+  by Casper Bach Poulsen and Cas Van Der Rest  
   ([doi](https://dl.acm.org/doi/abs/10.1145/3571255))
   ([pdf](http://casperbp.net/store/hefty-algebras.pdf))
 


### PR DESCRIPTION
Caspar -> Casper, see spelling here https://dl.acm.org/doi/abs/10.1145/3571255 or http://casperbp.net/