### PR TITLE
Remove broken link for "First Class Dynamic Effect Handlers".

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,6 @@ in various programming languages.
 
 * **First Class Dynamic Effect Handlers: or, Polymorphic Heaps with Dynamic Effect Handlers** (TyDe 2018)  
   by Daan Leijen  
-  ([acm dl](https://dl.acm.org/citation.cfm?id=3241789))
 
 * **Algebraic Effect Handlers with Resources and Deep Finalization** (MSR technical report)  
   by Daan Leijen  


### PR DESCRIPTION
Remove the flaky ACM link for "First Class Dynamic Effect Handlers", which is [causing CI to fail](https://github.com/yallop/effects-bibliography/actions/runs/5755411983/job/15602777330?pr=175)

@daanx, if you have a non-ACM link that we could use instead, it'd be appreciated.