### PR TITLE
Updates to paper, software, and tutorial sections

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,3 @@
 https://dl.acm.org/doi/pdf/.*
 https://www.cs.uoregon.edu/research/summerschool/.*
+https://www.macs.hw.ac.uk/splv/.*

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ in various programming languages.
 * **Coop**: A prototype programming language for programming with runners  
   by Andrej Bauer and Danel Ahman  
   ([www](https://github.com/andrejbauer/coop))
-  
+
 * **Desk**: A statically-typed functional language with an effect system based on set-operation  
   by Ryo Hirayama from Hihaheho Studio  
   ([GitHub](https://github.com/Hihaheho/Desk)) ([an effects tutorial article](https://github.com/Hihaheho/Desk/blob/main/docs/blog/0002-algebraic-effects.md))
@@ -87,6 +87,7 @@ in various programming languages.
 * **Multicore OCaml**: a multicore + effect handlers extension for OCaml  
   by Stephen Dolan, Anil Madhavapeddy, KC Sivaramakrishnan, Leo White, and Jeremy Yallop  
   ([www](https://github.com/ocaml-multicore/ocaml-multicore/wiki))
+  (now incorporated into [OCaml 5+](https://github.com/ocaml/ocaml))
 
 * **Polysemy**: a Haskell library for effects  
   by Sandy Maguire  

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ in various programming languages.
   ([www](https://www.unisonweb.org/docs/language-reference#abilities-and-ability-handlers))
   ([GitHub](https://github.com/unisonweb/unison))
 
+* **WasmFXtime**: A fork of Wasmtime extended with support for effect handlers  
+  by Luna Phipps-Costin, Frank Emrich, and  Daniel Hillerström  
+  ([www](https://wasmfx.dev))
+  ([GitHub](https://github.com/wasmfx/wasmfxtime))
+
 * **Wasm/k**: WebAssembly, extended with support for first-class continuations  
   by Donald Pinckney  
   ([www](https://wasmk.github.io/))
@@ -120,11 +125,11 @@ in various programming languages.
   by Eric Torreborre  
   ([www](http://atnos-org.github.io/eff/))
   ([GitHub](http://github.com/atnos-org/eff))
-  
+
 * **cpp-effects**: effect handlers in C++  
   by Maciej Piróg  
   ([GitHub](https://github.com/maciejpirog/cpp-effects))
-  
+
 * **libhandler**: an implementation of algebraic effects and handlers in portable C99  
   by Daan Leijen  
   ([www](https://github.com/koka-lang/libhandler))
@@ -132,7 +137,7 @@ in various programming languages.
 * **libmprompt**: robust multi-prompt delimited control and effect handlers in C/C++  
   by Daan Leijen  
   ([www](https://github.com/koka-lang/libmprompt))
-  
+
 * **multicont**: continuations with multi-shot semantics in OCaml  
   by Daniel Hillerström  
   ([www](https://github.com/dhil/ocaml-multicont))
@@ -153,6 +158,11 @@ in various programming languages.
 ## Tutorials
 
 ### 2022
+
+* **Effect-Handler Oriented Programming** (lecture given at [SPLV](https://www.macs.hw.ac.uk/splv/splv-2022/))  
+  by Sam Lindley  
+  ([YouTube](https://www.youtube.com/watch?v=G8XMRZKOhG0))
+  ([slides](https://www.macs.hw.ac.uk/splv/wp-content/uploads/2022/07/ehop.pdf))
 
 * **Effect handler oriented programming** (lecture series given at [OPLSS](https://www.cs.uoregon.edu/research/summerschool/summer22/topics.php#Lindley))  
   by Sam Lindley  
@@ -196,6 +206,11 @@ in various programming languages.
 ## Papers
 
 ### 2023
+
+* **Continuing WebAssembly with Effect Handlers** (OOPSLA 2023)  
+  by Luna Phipps-Costin, Andreas Rossberg, Arjun Guha, Daan Leijen, Daniel Hillerström, KC Sivaramakrishnan, Matija Pretnar, and Sam Lindley  
+  ([doi](https://doi.org/10.1145/3622814))
+  ([arxiv](https://doi.org/10.48550/arXiv.2308.08347))
 
 * **Typed equivalence of labeled effect handlers and labeled delimited control operators** (PPDP 2023)  
   by Kazuki Ikemori, Youyou Cong, and Hidehiko Masuhara  

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in various programming languages.
 
 * **Coop**: A prototype programming language for programming with runners  
   by Andrej Bauer and Danel Ahman  
-  ([www](https://github.com/andrejbauer/coop))
+  ([GitHub](https://github.com/andrejbauer/coop))
 
 * **Desk**: A statically-typed functional language with an effect system based on set-operation  
   by Ryo Hirayama from Hihaheho Studio  
@@ -31,11 +31,11 @@ in various programming languages.
 
 * **Eff in F#**: A library for programming with algebraic effects in F#  
   by Nick Palladinos  
-  ([www](https://github.com/palladin/Eff))
+  ([GitHub](https://github.com/palladin/Eff))
 
 * **Effects.js**: algebraic effects for Javascript based on Koka and Eff  
   by Jason Butler  
-  ([www](https://github.com/nythrox/effects.js))
+  ([GitHub](https://github.com/nythrox/effects.js))
 
 * **Effekt Language**: A research language with effect handlers and lightweight effect polymorphism  
   by Jonathan Brachthäuser, Philipp Schuster, and Klaus Ostermann  
@@ -43,7 +43,7 @@ in various programming languages.
 
 * **EvEff**: A Haskell library for programming with evidence-translated effect handlers  
   by Daan Leijen and Ningning Xie  
-  ([www](https://github.com/xnning/EvEff))
+  ([GitHub](https://github.com/xnning/EvEff))
 
 * **Extensible effects**: a Haskell library for effects  
   by Oleg Kiselyov  
@@ -56,20 +56,20 @@ in various programming languages.
 
 * **Frank**: programming language with first-class handlers, invisible effect variables, and multihandlers  
   by Sam Lindley, Conor McBride, and Craig McLaughlin  
-  ([www](https://github.com/frank-lang/frank))
+  ([GitHub](https://github.com/frank-lang/frank))
 
 * **Freak**: a programming language with coalgebraic effects and cohandlers  
   by Mateusz Urbańczyk  
-  ([www](https://github.com/Tomatosoup97/freak))
+  ([GitHub](https://github.com/Tomatosoup97/freak))
 
 * **Fused effects**: a Haskell library for effects  
   by Rob Rix  
   ([hackage](https://hackage.haskell.org/package/fused-effects))
-  ([www](https://github.com/robrix/fused-effects))
+  ([GitHub](https://github.com/robrix/fused-effects))
 
 * **Helium**: a functional programming language with effect handlers and an ML-like module system  
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
-  ([www](https://bitbucket.org/pl-uwr/helium))
+  ([BitBucket](https://bitbucket.org/pl-uwr/helium))
 
 * **Idris Effects**: library for algebraic effects and handlers in Idris - inspired by Eff language  
   by Edwin Brady  
@@ -78,7 +78,7 @@ in various programming languages.
 
 * **Koka**: a function-oriented language with effect inference  
   by Daan Leijen  
-  ([www](https://github.com/koka-lang/koka))
+  ([GitHub](https://github.com/koka-lang/koka))
 
 * **Links effect handlers**: an effect handlers extension for the Links web programming language  
   by Daniel Hillerström and Sam Lindley  
@@ -87,13 +87,13 @@ in various programming languages.
 
 * **Multicore OCaml**: a multicore + effect handlers extension for OCaml  
   by Stephen Dolan, Anil Madhavapeddy, KC Sivaramakrishnan, Leo White, and Jeremy Yallop  
-  ([www](https://github.com/ocaml-multicore/ocaml-multicore/wiki))
+  ([GitHub](https://github.com/ocaml-multicore/ocaml-multicore/wiki))
   (now incorporated into [OCaml 5+](https://github.com/ocaml/ocaml))
 
 * **Polysemy**: a Haskell library for effects  
   by Sandy Maguire  
   ([hackage](http://hackage.haskell.org/package/polysemy))
-  ([www](https://github.com/polysemy-research/polysemy))
+  ([GitHub](https://github.com/polysemy-research/polysemy))
 
 * **Pyro**: a deep universal probabilistic programming language  
   by Uber AI Labs  
@@ -101,7 +101,7 @@ in various programming languages.
 
 * **Scala Effekt**: extensible algebraic effects with handlers in Scala  
   by Jonathan Brachthäuser  
-  ([www](https://github.com/b-studios/scala-effekt))
+  ([GitHub](https://github.com/b-studios/scala-effekt))
 
 * **Unison**: a programming language with effects called abilities, inspired by Frank  
   by Unison Computing  
@@ -134,19 +134,19 @@ in various programming languages.
 
 * **libhandler**: an implementation of algebraic effects and handlers in portable C99  
   by Daan Leijen  
-  ([www](https://github.com/koka-lang/libhandler))
+  ([GitHub](https://github.com/koka-lang/libhandler))
 
 * **libmprompt**: robust multi-prompt delimited control and effect handlers in C/C++  
   by Daan Leijen  
-  ([www](https://github.com/koka-lang/libmprompt))
+  ([GitHub](https://github.com/koka-lang/libmprompt))
 
 * **multicont**: continuations with multi-shot semantics in OCaml  
   by Daniel Hillerström  
-  ([www](https://github.com/dhil/ocaml-multicont))
+  ([GitHub](https://github.com/dhil/ocaml-multicont))
 
 * **shonky**: a dynamically typed variant of Frank with C-like syntax  
   by Conor McBride  
-  ([www](https://github.com/pigworker/shonky))
+  ([GitHub](https://github.com/pigworker/shonky))
 
 * **Turbolift**: algebraic effects for Scala 3  
   by Marcin Żebrowski  

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ in various programming languages.
 
 * **Abstract Nonsense** (FARM 2018)  
   by Junia Gonçalves  
-  ([acm dl](https://dl.acm.org/citation.cfm?id=3242908))
+  ([doi](https://doi.org/10.1145/3242903.3242908))
 
 * **Syntax and Semantics for Operations with Scopes**  (LICS 2018)  
   by Maciej Piróg, Tom Schrijvers, Nicolas Wu, and Mauro Jaskelioff  

--- a/README.md
+++ b/README.md
@@ -589,11 +589,11 @@ in various programming languages.
 
 * **JEff: Objects for Effect** (Onward 2018)  
   by Pablo Inostroza and Tijs van der Storm  
-  ([acm dl](https://homepages.cwi.nl/~storm/publications/jeff.pdf))
+  ([pdf](https://homepages.cwi.nl/~storm/publications/jeff.pdf))
 
 * **Effect Handlers for the Masses** (OOPSLA 2018)  
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, and Klaus Ostermann  
-  ([acm dl](https://dl.acm.org/doi/pdf/10.1145/3276481))
+  ([pdf](https://dl.acm.org/doi/pdf/10.1145/3276481))
 
 * **Abstract Nonsense** (FARM 2018)  
   by Junia Gonçalves  
@@ -605,6 +605,7 @@ in various programming languages.
 
 * **First Class Dynamic Effect Handlers: or, Polymorphic Heaps with Dynamic Effect Handlers** (TyDe 2018)  
   by Daan Leijen  
+  ([doi](https://doi.org/10.1145/3240719.3241789))
 
 * **Algebraic Effect Handlers with Resources and Deep Finalization** (MSR technical report)  
   by Daan Leijen  

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ in various programming languages.
 
 * **Links effect handlers**: an effect handlers extension for the Links web programming language  
   by Daniel Hillerström and Sam Lindley  
-  ([www](https://github.com/links-lang/links))
+  ([www](https://links-lang.org))
+  ([GitHub](https://github.com/links-lang/links))
 
 * **Multicore OCaml**: a multicore + effect handlers extension for OCaml  
   by Stephen Dolan, Anil Madhavapeddy, KC Sivaramakrishnan, Leo White, and Jeremy Yallop  


### PR DESCRIPTION
Adds:
* OOPSLA'23 paper
* WasmFXtime
* SPLV'22 lecture

In addition, I have made the hyperlink identifiers in the software section more consistent. I have also removed some irrelevant trailing whitespace.