### PR TITLE
Clean-up & DBLP links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,3 +4,4 @@ https://www.cs.uoregon.edu/research/summerschool/.*
 https://www.macs.hw.ac.uk/splv/.*
 https://doi.org/10.1145/.*
 https://dblp.uni-trier.de/rec/.*
+https://ecommons.cornell.edu/handle/.*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,3 +3,4 @@ https://www.cs.drexel.edu/.*
 https://www.cs.uoregon.edu/research/summerschool/.*
 https://www.macs.hw.ac.uk/splv/.*
 https://doi.org/10.1145/.*
+https://dblp.uni-trier.de/rec/.*

--- a/README.md
+++ b/README.md
@@ -1344,7 +1344,7 @@ in various programming languages.
 
 * **Types and trace effects of higher-order programs** (JFP 2008)  
   by Christian Skalka, Scott Smith, and David van Horn  
-  ([doi](https://doi.org/10.1017/S0956796807006466))
+  ([doi](https://dl.acm.org/doi/10.1017/S0956796807006466))
 
 ### 2007
 
@@ -1475,8 +1475,7 @@ in various programming languages.
 ### 1988
 
 * **Polymorphic effect systems** (POPL 1988)  
-  by John M. Lucassen and David K. Gifford  
-  ([pdf](http://groups.csail.mit.edu/pag/OLD/parg/lucassen88effects.pdf))
+  by John M. Lucassen and David K. Gifford
 
 * **The FX-87 Interpreter** (ICCL 1988)  
   by Pierre Jouvelot and David K. Gifford  
@@ -1566,7 +1565,7 @@ in various programming languages.
 
 * **Defined Algebraic Operations** (PhD Dissertation, University of Birmingham)  
   by Bram Geron  
-  ([pdf](https://bram.xyz/thesis.pdf))
+  ([pdf](https://etheses.bham.ac.uk//id/eprint/10520/1/Geron2020PhD.pdf))
 
 ### 2018
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ in various programming languages.
 
 * **An Introduction to Algebraic Effects and Handlers** (MFPS 2015)  
   by Matija Pretnar  
-  ([dblp](http://dblp.uni-trier.de/rec/html/journals/entcs/Pretnar15))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/journals/entcs/Pretnar15?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/Pretnar15.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/entcs/Pretnar15.html?view=bibtex))
   ([doi](http://dx.doi.org/10.1016/j.entcs.2015.12.003))
   ([pdf](http://www.eff-lang.org/handlers-tutorial.pdf))
 
@@ -758,19 +758,19 @@ in various programming languages.
 
 * **Do be do be do** (POPL 2017)  
   by Sam Lindley, Conor McBride, and Craig McLaughlin  
-  ([dblp](http://dblp.uni-trier.de/rec/html/conf/popl/LindleyMM17))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/conf/popl/LindleyMM17?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/popl/LindleyMM17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/popl/LindleyMM17.html?view=bibtex))
   ([arxiv](https://arxiv.org/pdf/1611.09259))
 
 * **Type directed compilation of row-typed algebraic effects** (POPL 2017)  
   by Daan Leijen  
-  ([dblp](http://dblp.uni-trier.de/rec/html/conf/popl/Leijen17))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/conf/popl/Leijen17?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/popl/Leijen17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/popl/Leijen17.html?view=bibtex))
 
 * **No value restriction is needed for algebraic effects and handlers** (J. Funct. Program. 2017)  
   by Ohad Kammar and Matija Pretnar  
-  ([dblp](http://dblp.uni-trier.de/rec/html/journals/jfp/KammarP17))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/journals/jfp/KammarP17?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/KammarP17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/KammarP17.html?view=bibtex))
   ([arxiv](https://arxiv.org/pdf/1605.06938))
 
 ### 2016
@@ -803,14 +803,14 @@ in various programming languages.
 * **Liberating effects with rows and handlers** (TyDe 2016)  
   by Daniel Hillerström and Sam Lindley  
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
-  ([dblp](http://dblp.uni-trier.de/rec/html/conf/icfp/HillerstromL16))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/conf/icfp/HillerstromL16?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/HillerstromL16.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/HillerstromL16.html?view=bibtex))
 
 * **Dependent Types and Fibred Computational Effects** (FoSSaCS 2016)  
   by Danel Ahman, Neil Ghani, and Gordon Plotkin  
   ([pdf](https://danelahman.github.io/papers/fossacs16.pdf))
-  ([dblp](http://dblp.org/rec/conf/fossacs/AhmanGP16))
-  ([bibtex](http://dblp.org/rec/conf/fossacs/AhmanGP16?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/fossacs/AhmanGP16.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/fossacs/AhmanGP16.html?view=bibtex))
   
 * **From Monads to Effects and Back** (PADL 2016)  
   by Niki Vazou and Daan Leijen  
@@ -841,8 +841,8 @@ in various programming languages.
 * **Programming with Algebraic Effects and Handlers** (JLAMP 2015)  
   by Andrej Bauer and Matija Pretnar  
   ([arxiv](http://math.andrej.com/wp-content/uploads/2012/03/eff.pdf))
-  ([dblp](http://dblp.uni-trier.de/rec/html/journals/jlp/BauerP15))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/journals/jlp/BauerP15?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jlp/BauerP15.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jlp/BauerP15.html?view=bibtex))
   ([doi](http://dx.doi.org/10.1016/j.jlamp.2014.02.001))
 
 * **Fusion for Free: Efficient Algebraic Effect Handlers** (MPC 2015)  
@@ -851,8 +851,8 @@ in various programming languages.
 
 * **Interleaving data and effects** (JFP 2015)  
   by Robert Atkey and Patricia Johann  
-  ([dblp](http://dblp.uni-trier.de/rec/html/journals/jfp/AtkeyJ15))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/journals/jfp/AtkeyJ15?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/AtkeyJ15.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/AtkeyJ15.html?view=bibtex))
   ([doi](http://dx.doi.org/10.1017/S0956796815000209))
   ([pdf](http://bentnib.org/interleaving.pdf))
 
@@ -868,8 +868,8 @@ in various programming languages.
 
 * **Algebraic effects and effect handlers for idioms and arrows** (WGP 2014)  
   by Sam Lindley  
-  ([dblp](http://dblp.uni-trier.de/rec/html/conf/icfp/Lindley14))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/conf/icfp/Lindley14?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Lindley14.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/Lindley14.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/aeia.pdf))
 
 * **A Theory of Gradual Effect Systems** (ICFP 2014)  
@@ -891,15 +891,15 @@ in various programming languages.
 * **Inferring algebraic effects** (LMCS 2014)  
   by Matija Pretnar  
   ([arxiv](http://arxiv.org/pdf/1312.2334.pdf))
-  ([dblp](http://dblp.uni-trier.de/rec/html/journals/corr/Pretnar13))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/journals/corr/Pretnar13?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/Pretnar13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/Pretnar13.html?view=bibtex))
   ([doi](http://dx.doi.org/10.2168/LMCS-10%283:21%292014))
 
 * **An Effect System for Algebraic Effects and Handlers** (LMCS 2014)  
   by Andrej Bauer and Matija Pretnar  
   ([arxiv](http://arxiv.org/pdf/1306.6316.pdf))
-  ([dblp](http://dblp.uni-trier.de/rec/html/journals/corr/BauerP13))
-  ([bibtex](http://dblp.uni-trier.de/rec/html/journals/corr/BauerP13?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/BauerP13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/BauerP13.html?view=bibtex))
   ([doi](http://dx.doi.org/10.2168/LMCS-10%284:9%292014))
 
 * **Parametric Effect Monads and Semantics of Effect Systems** (POPL 2014)  
@@ -927,15 +927,15 @@ in various programming languages.
 
 * **JavaUI: Effects for UI Object Access** (ECOOP 2013)  
   by Colin S. Gordon, Werner Dietl, Michael D. Ernst and Dan Grossman  
-  ([dblp](http://dblp.uni-trier.de/rec/html/conf/ecoop/GordonDEG13))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/GordonDEG13.html))
   ([doi](http://dx.doi.org/10.1007/978-3-642-39038-8_8))
   ([pdf](https://www.cs.drexel.edu/~csgordon/papers/ecoop13.pdf))
 
 * **Handling algebraic effects** (LMCS 2013)  
   by Gordon Plotkin and Matija Pretnar  
   ([arxiv](http://arxiv.org/abs/1312.1399))
-  ([dblp](http://dblp.org/rec/journals/corr/PlotkinP13))
-  ([bibtex](http://dblp.org/rec/journals/corr/PlotkinP13?view=bibtex))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/PlotkinP13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/PlotkinP13.html?view=bibtex))
   ([doi](http://dx.doi.org/10.2168/LMCS-9%284:23%292013))
 
 * **Normalization by Evaluation and Algebraic Effects** (MFPS 2013)  

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ in various programming languages.
 
 * **What is algebraic about algebraic effects and handlers?** (tutorial given at [Dagstuhl](https://www.dagstuhl.de/en/program/calendar/semhp/?semnr=18172) and [OPLSS](https://www.cs.uoregon.edu/research/summerschool/summer18/topics.php))  
   by Andrej Bauer  
+  ([doi](http://arxiv.org/abs/1807.05923))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-1807-05923.html))
   ([pdf](https://arxiv.org/pdf/1807.05923))  
   (Videos: [1.1](https://www.cs.uoregon.edu/research/summerschool/summer18/lectures/bauer1-1.mp4),
            [1.2](https://www.cs.uoregon.edu/research/summerschool/summer18/lectures/bauer1-2.mp4),
@@ -217,32 +219,38 @@ in various programming languages.
 * **Asymptotic speedup via effect handlers** (JFP 2024)  
   by Daniel Hillerström, Sam Lindley, and John Longley  
   ([doi](https://doi.org/10.1017/S0956796824000030))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/HillerstromLL24.html))
   ([pdf](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/296879DE2FD96FB6CF388F27978C76E4/S0956796824000030a.pdf/asymptotic-speedup-via-effect-handlers.pdf))
 
 * **Active Objects Based on Algebraic Effects** (Active Object Languages: Current Research Trends)  
   by Martin Andrieux, Ludovic Henrio, and Gabriel Radanne  
   ([doi](https://doi.org/10.1007/978-3-031-51060-1_1))
+  ([dblp](https://dblp.uni-trier.de/rec/books/sp/24/AndrieuxHR24.html))
   ([pdf](https://hal.science/hal-04388798/document))
 
 * **Soundly Handling Linearity** (POPL 2024)  
   by Wenhao Tang, Daniel Hillerström, Sam Lindley, and J. Garrett Morris  
   ([doi](https://doi.org/10.1145/3632896))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/TangHLM24.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3632896))
 
 * **On Model-Checking Higher-Order Effectful Programs** (POPL 2024)  
   by Ugo Dal Lago and Alexis Ghyselen  
   ([doi](https://doi.org/10.1145/3632929))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/LagoG24.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3632929))
   ([pdf (extended version)](https://arxiv.org/abs/2308.16542))
 
 * **Effectful Software Contracts** (POPL 2024)  
   by Cameron Moy, Christos Dimoulas, and Matthias Felleisen  
   ([doi](https://doi.org/10.1145/3632930))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/MoyDF24.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3632930))
 
 * **An Intrinsically Typed Compiler for Algebraic Effect Handlers** (PEPM 2024)  
   by Syouki Tsuyama, Youyou Cong, and Hidehiko Masuhara  
   ([doi](https://doi.org/10.1145/3635800.3636968))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/pepm/TsuyamaCM24.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3635800.3636968))
 
 ### 2023
@@ -250,83 +258,111 @@ in various programming languages.
 * **From Capabilities to Regions: Enabling Efficient Compilation of Lexical Effect Handlers** (OOPSLA 2023)  
   by Marius Müller, Philipp Schuster, Jonathan Lindegaard Starup, Klaus Ostermann, and Jonathan Immanuel Brachthäuser  
   ([doi](https://doi.org/10.1145/3622831))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/MullerSSOB23.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3622831))
 
 * **Continuing WebAssembly with Effect Handlers** (OOPSLA 2023)  
   by Luna Phipps-Costin, Andreas Rossberg, Arjun Guha, Daan Leijen, Daniel Hillerström, KC Sivaramakrishnan, Matija Pretnar, and Sam Lindley  
   ([doi](https://doi.org/10.1145/3622814))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/PhippsCostinRGLHSPL23.html))
   ([arxiv](https://doi.org/10.48550/arXiv.2308.08347))
 
 * **Typed equivalence of labeled effect handlers and labeled delimited control operators** (PPDP 2023)  
   by Kazuki Ikemori, Youyou Cong, and Hidehiko Masuhara  
+  ([doi](https://doi.org/10.1145/3610612.3610616))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ppdp/IkemoriCM23.html))
   ([pdf](https://prg.is.titech.ac.jp/papers/pdf/ppdp2023.pdf))
   ([bibtex](https://dblp.org/rec/conf/ppdp/IkemoriCM23.html?view=bibtex))
 
 * **Error Localization for Sequential Effect Systems** (SAS 2023)  
   by Colin S. Gordon, Chaewon Yun  
   ([doi](https://doi.org/10.1007/978-3-031-44245-2_16))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/sas/GordonY23.html))
 
 * **A General Fine-Grained Reduction Theory for Effect Handlers** (ICFP 2023)  
   by Filip Sieczkowski, Mateusz Pyzik, and Dariusz Biernacki  
   ([doi](https://doi.org/10.1145/3607848))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SieczkowskiPB23.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3607848))
 
 * **With or Without You: Programming with Effect Exclusion** (ICFP 2023)  
   by Matthew Lutze, Magnus Madsen, Philipp Schuster, and Jonathan Immanuel Brachthäuser  
   ([doi](https://doi.org/10.1145/3607846))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/LutzeMSB23.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3607846))
 
 * **Hefty Algebras: Modular Elaboration of Higher-Order Algebraic Effects** (POPL 2023)  
   by Casper Bach Poulsen and Cas Van Der Rest  
   ([doi](https://dl.acm.org/doi/abs/10.1145/3571255))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/PoulsenR23.html))
   ([pdf](http://casperbp.net/store/hefty-algebras.pdf))
 
 * **Towards a Reflection for Effect Handlers** (PEPM 2023)  
   by Youyou Cong and Kenichi Asai  
   ([doi](https://dl.acm.org/doi/abs/10.1145/3571786.3573015))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/pepm/CongA23.html))
 
 ### 2022
 
 * **Category-Graded Algebraic Theories and Effect Handlers** (MFPS 2022)  
   by Takahiro Sanada  
+  ([doi](https://doi.org/10.46298/entics.10491))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2212-07015.html))
   ([pdf](https://www.kurims.kyoto-u.ac.jp/~tsanada/papers/mfps2022-cat-graded-preproceedings-extended.pdf))
 
 * **Modular probabilistic models via algebraic effects** (ICFP 2022)  
   by Minh Nguyen, Roly Perera, Meng Wang, and Nicolas Wu  
+  ([doi](https://doi.org/10.1145/3547635))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/NguyenPWW22.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3547635))
 
 * **Automated Temporal Veriﬁcation for Algebraic Effects** (APLAS 2022)  
   by Yahui Song, Darius Foo, and Wei-Ngan Chin  
+  ([doi](https://doi.org/10.1007/978-3-031-21037-2_5))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/SongFC22.html))
   ([pdf](https://www.comp.nus.edu.sg/~yahuis/APLAS2022.pdf))
 
 * **An Algebraic Theory for Shared-State Concurrency** (APLAS 2022)  
   by Yotam Dvir, Ohad Kammar, and Ori Lahav  
+  ([doi](https://doi.org/10.1007/978-3-031-21037-2_1))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/DvirKL22.html))
   ([pdf](https://www.cs.tau.ac.il/~orilahav/papers/aplas22full.pdf))
 
 * **First-class Names for Effect Handlers** (OOPSLA 2022)  
   by Ningning Xie, Youyou Cong, Kazuki Ikemori, and Daan Leijen  
+  ([doi](https://doi.org/10.1145/3563289))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XieCIL22.html))
   ([pdf](https://xnning.github.io/papers/oopsla22namedh.pdf))
 
 * **High-level effect handlers in C++** (OOPSLA 2022)  
   by Dan Ghica, Sam Lindley, Marcos Maroñas Bravo, and Maciej Piróg  
+  ([doi](https://doi.org/10.1145/3563445))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/GhicaLBP22.html))
   ([pdf](https://homepages.inf.ed.ac.uk/slindley/papers/cppeff.pdf))
 
 * **Algebraic effects for extensible dynamic semantics** (Journal of Logic, Language and Information)  
   by Julian Grove and Jean-Philippe Bernardy  
+  ([doi](https://doi.org/10.1007/s10849-022-09378-7))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jolli/GroveB23.html))
   ([pdf](https://semanticsarchive.net/Archive/TMxNGE3M/algebraic.pdf))
 
 * **A Typed Continuation-Passing Translation for Lexical Effect Handlers** (PLDI 2022)  
   by Philipp Schuster, Jonathan Immanuel Brachthäuser, Marius Müller, and Klaus Ostermann  
   ([doi](https://doi.org/10.1145/3519939.3523710))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/pldi/SchusterB0O22.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3519939.3523710))
 
 * **Structured Handling of Scoped Effects** (ESOP 2022)  
   by Zhixuan Yang, Marco Paviotti, Nicolas Wu, Birthe van den Berg, and Tom Schrijvers  
+  ([doi](https://doi.org/10.1007/978-3-030-99336-8_17))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/esop/YangPWBS22.html))
   ([pdf](https://link.springer.com/content/pdf/10.1007/978-3-030-99336-8_17.pdf))
   ([pdf (extended version)](https://arxiv.org/pdf/2201.10287.pdf))
 
 * **Effects, Capabilities, and Boxes: From Scope-Based Reasoning to Type-Based Reasoning and Back** (OOPSLA 2022)  
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, Edward Lee, and Aleksander Boruch-Gruszecki  
+  ([doi](https://doi.org/10.1145/3527320))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSLB22.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3527320))
 
 ### 2021
@@ -334,11 +370,13 @@ in various programming languages.
 * **Efficient Compilation of Algebraic Effect Handlers** (OOPSLA 2021)  
   by Georgios Karachalias, Filip Koprivec, Matija Pretnar, and Tom Schrijvers  
   ([doi](https://doi.org/10.1145/3485479))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/KarachaliasKPS21.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3485479))
 
 * **Latent Effects for Resuable Language Components** (APLAS 2021)  
   by Birthe van den Berg, Tom Schrijvers, Casper Bach Poulsen, and Nicolas Wu  
   ([doi](https://doi.org/10.1007/978-3-030-89051-3_11))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/BergSPW21.html))
   ([arxiv](https://arxiv.org/abs/2108.11155))
   ([pdf (extended version)](https://arxiv.org/pdf/2108.11155.pdf))
 
@@ -349,32 +387,38 @@ in various programming languages.
 * **Safe mutation with algebraic effects** (Haskell 2021)  
   by Hashan Punchihewa and Nicolas Wu  
   ([doi](https://doi.org/10.1145/3471874.3472988))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/PunchihewaW21.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3471874.3472988))
 
 * **Contextual Modal Types for Algebraic Effects and Handlers** (ICFP 2021)  
   by Nikita Zyuzin and Aleksandar Nanevski  
   ([doi](https://doi.org/10.1145/3473580))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/ZyuzinN21.html))
   ([pdf](https://software.imdea.org/~aleks/icfp21/icfp21.pdf))
 
 * **Reasoning about Effect Interaction by Fusion** (ICFP 2021)  
   by Zhixuan Yang and Nicolas Wu
   ([doi](https://doi.org/10.1145/3473578))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/YangW21.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3473578))
   ([extended pdf](https://yangzhixuan.github.io/pdf/fused-reasoning-appendices.pdf))
 
 * **Generalized Evidence Passing for Effect Handlers** (ICFP 2021)  
   by Ningning Xie and Daan Leijen  
   ([doi](https://doi.org/10.1145/3473576))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XieL21.html))
   ([pdf](https://xnning.github.io/papers/multip.pdf))
 
 * **A Functional Abstraction of Typed Invocation Contexts** (FSCD 2021)  
   by Youyou Cong, Chiaki Ishio, Kaho Honda, and Kenichi Asai  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2021.12))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/fscd/CongIHA21.html))
   ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14250/pdf/LIPIcs-FSCD-2021-12.pdf))
 
 * **Derivation of a Virtual Machine For Four Variants of Delimited-Control Operators** (FSCD 2021)  
   by Maika Fujii and Kenichi Asai  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2021.16))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/fscd/FujiiA21.html))
   ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14254/pdf/LIPIcs-FSCD-2021-16.pdf))
 
 * **Contextual Effect Polymorphism Meets Bidirectional Effects (Extended Abstract)** (TyDe 2021)  
@@ -399,12 +443,15 @@ in various programming languages.
 
 * **Retrofitting Effect Handlers onto OCaml** (PLDI 2021)  
   by KC Sivaramakrishnan, Stephen Dolan, Leo White, Tom Kelly, Sadiq Jaffer, and Anil Madhavapeddy  
+  ([doi](https://doi.org/10.1145/3453483.3454039))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/pldi/Sivaramakrishnan21.html))
   ([arxiv](https://arxiv.org/abs/2104.00250))
   ([pdf](https://arxiv.org/pdf/2104.00250.pdf))
 
 * **Polymorphic Iterable Sequential Effect Systems** (TOPLAS 2021)  
   by Colin S. Gordon  
   ([doi](https://doi.org/10.1145/3450272))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/toplas/Gordon21.html))
   ([arxiv](https://arxiv.org/abs/1808.02010))
 
 * **Automatic Differentiation via Effects and Handlers: An Implementation in Frank** (PEPM 2021)  
@@ -417,11 +464,14 @@ in various programming languages.
 
 * **A Separation Logic for Effect Handlers** (POPL 2021)  
   by Paulo Emílio de Vilhena and François Pottier  
+  ([doi](https://doi.org/10.1145/3434314))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/VilhenaP21.html))
   ([pdf](https://inria.hal.science/hal-03049514v1/document))
 
 * **Asynchronous Effects** (POPL 2021)  
   by Danel Ahman and Matija Pretnar  
   ([doi](https://doi.org/10.1145/3434305))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/AhmanP21.html))
   ([arxiv](https://arxiv.org/abs/2003.02110))
   ([pdf](https://arxiv.org/pdf/2003.02110.pdf))
 
@@ -429,56 +479,72 @@ in various programming languages.
 
 * **Graded Algebraic Theories** (FoSSaCS 2020)  
   by Satoshi Kura  
+  ([doi](https://doi.org/10.1007/978-3-030-45231-5_21))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/fossacs/Kura20.html))
   ([pdf](https://link.springer.com/content/pdf/10.1007/978-3-030-45231-5_21.pdf))
 
 * **Modular verification of programs with effects and effects handlers** (FAOC 2020)  
   by Thomas Letan, Yann Régis-Gianas, Pierre Chifflier, and Guillaume Hiet  
   ([doi](https://dx.doi.org/10.1007/s00165-020-00523-2))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/fac/LetanRCH21.html))
 
 * **Not by equations alone: reasoning with extensible effects** (JFP 2020)  
   by Oleg Kiselyov, Shin-Cheng Mu, and Amr Sabry  
+  ([doi](https://doi.org/10.1017/S0956796820000271))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/KiselyovMS21.html))
   ([pdf](https://www.okmij.org/ftp/Haskell/extensible/denot.pdf))
 
 * **Automatic Reparameterisation of Probabilistic Programs** (ICML 2020)  
   by Maria I. Gorinova, Dave Moore, and Matthew D. Hoffman  
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icml/GorinovaMH20.html))
   ([pdf](http://proceedings.mlr.press/v119/gorinova20a/gorinova20a.pdf))
 
 * **Compiling Symbolic Execution with Staging and Algebraic Effects** (OOPSLA 2020)  
   by Guannan Wei, Oliver Bračevac, Shangyin Tan, and Tiark Rompf  
   ([doi](https://doi.org/10.1145/3428232))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/WeiBTR20.html))
   ([pdf](https://bracevac.org/assets/pdf/oopsla20.pdf))
 
 * **Composing Effects into Tasks and Workflows** (Haskell 2020)  
   by Yves Parès, Jean-Philippe Bernardy, and Richard A. Eisenberg  
   ([doi](https://doi.org/10.1145/3410242))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/ParesBE20.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3406088.3409023))
 
 * **Handling Bidirectional Control Flow** (OOPSLA 2020)  
   Yizhou Zhang, Guido Salvaneschi, and Andrew C. Myers  
+  ([doi](https://doi.org/10.1145/3428207))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/ZhangSM20.html))
   ([pdf](https://www.cs.cornell.edu/andru/papers/ufo/bidirectional-effects.pdf))
 
 * **Designing with Static Capabilities and Effects: Use, Mention, and Invariants** (ECOOP 2020)  
   by Colin S. Gordon  
   ([doi](https://doi.org/10.4230/LIPIcs.ECOOP.2020.10))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/Gordon19.html))
   ([pdf](https://drops.dagstuhl.de/storage/00lipics/lipics-vol166-ecoop2020/LIPIcs.ECOOP.2020.10/LIPIcs.ECOOP.2020.10.pdf))
 
 * **Lifting Sequential Effects to Control Operators** (ECOOP 2020)  
   by Colin S. Gordon  
   ([doi](https://doi.org/10.4230/LIPIcs.ECOOP.2020.23))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/Gordon19a.html))
   ([pdf](https://drops.dagstuhl.de/storage/00lipics/lipics-vol166-ecoop2020/LIPIcs.ECOOP.2020.23/LIPIcs.ECOOP.2020.23.pdf))
 
 * **Degrading Lists** (PPDP 2020)  
   by Dylan McDermott, Maciej Piróg, and Tarmo Uustalu  
   ([doi](https://doi.org/10.1145/3414080.3414084))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ppdp/McDermottPU20.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3414080.3414084))
 
 * **Wasm/k: Delimited Continuations for WebAssembly** (DLS 2020)  
   by Donald Pinckney, Arjun Guha, and Yuriy Brun  
+  ([doi](https://doi.org/10.1145/3426422.3426978))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/dls/PinckneyGB20.html))
   ([pdf](https://wasmk.github.io/FullVersion.pdf))
 
 * **A Complete Normal-Form Bisimilarity for Algebraic Effects and Handlers** (FSCD 2020)  
   by Dariusz Biernacki, Sergueï Lenglet, and Piotr Polesiuk  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2020.7))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/fscd/BiernackiLP20.html))
   ([pdf](https://drops.dagstuhl.de/opus/volltexte/2020/12329/pdf/LIPIcs-FSCD-2020-7.pdf))
 
 * **A Reflection on Continuation-Composing Style** (FSCD 2020)  
@@ -488,145 +554,209 @@ in various programming languages.
 
 * **Effect Handlers in Haskell, Evidently** (Haskell 2020)  
   by Ningning Xie and Daan Leijen  
+  ([doi](https://doi.org/10.1145/3406088.3409022))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/XieL20.html))
   ([pdf](https://www.microsoft.com/en-us/research/uploads/prod/2020/07/effev.pdf))
 
 * **Effects as capabilities: effect handlers and lightweight effect polymorphism** (OOPSLA 2020)  
   by Jonathan Brachthäuser, Philipp Schuster, and Klaus Ostermann  
   ([doi](https://doi.org/10.1145/3428194))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSO20.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3428194))
 
 * **One-shot Algebraic Effects as Coroutines** (TFP 2020)  
   by Satoru Kawahara and Yukiyoshi Kameyama  
   ([doi](https://doi.org/10.1007/978-3-030-57761-2_8))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/sfp/KawaharaK20.html))
   ([pdf](http://logic.cs.tsukuba.ac.jp/~sat/pdf/tfp2020.pdf))
 
 * **Generalized Monoidal Effects And Handlers** (JFP 2020)  
   by Ruben P. Pieters, Exequiel Rivas, and Tom Schrijvers  
+  ([doi](https://doi.org/10.1017/S0956796820000106))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/PietersRS20.html))
   ([pdf](https://rubenpieters.github.io/assets/papers/JFP20-handlers.pdf))
 
 * **Signature restriction for polymorphic algebraic effects** (ICFP 2020)  
   by Taro Sekiyama, Takeshi Tsukada, and Atsushi Igarashi  
+  ([doi](https://doi.org/10.1145/3408999))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SekiyamaTI20.html))
   ([pdf](https://arxiv.org/pdf/2003.08138))
 
 * **Effects for Efficiency: Asymptotic Speedup with First-Class Control** (ICFP 2020)  
   by Daniel Hillerström, Sam Lindley, and John Longley  
+  ([doi](https://doi.org/10.1145/3408982))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/HillerstromLL20.html))
   ([arxiv](https://arxiv.org/abs/2007.00605))
 
 * **Effect Handlers, Evidently** (ICFP 2020)  
   by Ningning Xie, Jonathan Immanuel Brachthäuser, Daniel Hillerström, Philipp Schuster, and Daan Leijen  
+  ([doi](https://doi.org/10.1145/3408981))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XieBHSL20.html))
   ([pdf](https://www.dhil.net/research/papers/effect_handlers_evidently-extended-icfp2020.pdf))
 
 * **Compiling Effect Handlers in Capability-Passing Style** (ICFP 2020)  
   by Philipp Schuster, Jonathan Immanuel Brachthäuser, and Klaus Ostermann  
   ([doi](https://doi.org/10.1145/3408975))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SchusterBO20.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3408975))
 
 * **Effekt: Capability-passing style for type- and effect-safe, extensible effect handlers in Scala** (JFP 2020)  
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, and Klaus Ostermann  
+  ([doi](https://doi.org/10.1017/S0956796820000027))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/BrachthauserSO20.html))
   ([pdf](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/A19680B18FB74AD95F8D83BC4B097D4F/S0956796820000027a.pdf/effekt_capabilitypassing_style_for_type_and_effectsafe_extensible_effect_handlers_in_scala.pdf))
 
 * **Doo bee doo bee doo** (JFP 2020)  
   by Lukas Convent, Sam Lindley, Conor McBride, and Craig McLaughlin  
+  ([doi](https://doi.org/10.1017/S0956796820000039))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/ConventLMM20.html))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/frankly-jfp.pdf))
 
 * **Effect handlers via generalised continuations** (JFP 2020)  
   by Daniel Hillerström, Sam Lindley, and Robert Atkey  
+  ([doi](https://doi.org/10.1017/S0956796820000040))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/HillerstromLA20.html))
   ([pdf](https://dhil.net/research/papers/generalised_continuations-jfp2020.pdf))
 
 * **Runners in action** (ESOP 2020)  
   by Danel Ahman and Andrej Bauer  
+  ([doi](https://doi.org/10.1007/978-3-030-44914-8_2))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/esop/AhmanB20.html))
   ([arxiv](https://arxiv.org/pdf/1910.11629.pdf))
 
 * **Interaction Trees: Representing Recursive and Impure Programs in Coq** (POPL 2020)  
   by Li-yao Xia, Yannick Zakowski, Paul He, Chung-Kil Hur, Gregory Malecha, Benjamin C. Pierce, Steve Zdancewic  
+  ([doi](https://doi.org/10.1145/3371119))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XiaZHHMPZ20.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3371119?download=true))
 
 * **Binders by Day, Labels by Night: Effect Instances via Lexically Scoped Handlers** (POPL 2020)  
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
+  ([doi](https://doi.org/10.1145/3371116))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS20.html))
   ([pdf](https://maciejpirog.github.io/papers/binders-labels.pdf))
 
 * **Combining predicate transformer semantics for effects: a case study in parsing regular languages** (MSFP 2020)  
   by Anne Baanen and Wouter Swierstra  
+  ([doi](https://doi.org/10.4204/EPTCS.317.3))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2005-00197.html))
   ([pdf](https://arxiv.org/pdf/2005.00197v1.pdf))  
 
 * **From Equations to Distinctions: Two Interpretations of Effectful Computations** (MSFP 2020)  
   by Niels Voorneveld  
+  ([doi](https://doi.org/10.4204/EPTCS.317.1))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2005-00196.html))
   ([pdf](https://arxiv.org/pdf/2005.00196.pdf))  
   
 * **Unifying graded and parameterised monads** (MSFP 2020)  
   by Dominic Orchard, Philip Wadler and Harley Eades III  
+  ([doi](https://doi.org/10.4204/EPTCS.317.2))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2001-10274.html))
   ([pdf](https://arxiv.org/pdf/2001.10274.pdf))  
 
 * **Local Algebraic Effect Theories** (JFP 2020)  
   by Žiga Lukšič and Matija Pretnar  
   ([doi](https://doi.org/10.1017/S0956796819000212))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/LuksicP20.html))
   ([arxiv](https://arxiv.org/abs/2005.13654))  
 
 * **Explicit Effect Subtyping** (JFP 2020)  
   by Georgios Karachalias, Matija Pretnar, Amr Hany Saleh, Stien Vanderhallen and Tom Schrijvers  
+  ([doi](https://doi.org/10.1017/S0956796820000131))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/KarachaliasPSVS20.html))
   ([arxiv](https://arxiv.org/abs/2005.13814))  
 
 * **The Fire Triangle: How to Mix Substitution, Dependent Elimination, and Effects** (POPL 2020)  
   by Pierre-Marie Pédrot and Nicolas Tabareau  
+  ([doi](https://doi.org/10.1145/3371126))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/PedrotT20.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3371126))
 
 ### 2019
 
 * **A Sound and Complete Logic for Algebraic Effects** (FoSSaCS 2019)  
   by Cristina Matache and Sam Staton  
+  ([doi](https://doi.org/10.1007/978-3-030-17127-8_22))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/fossacs/MatacheS19.html))
   ([pdf](http://www.cs.ox.ac.uk/people/samuel.staton/papers/fossacs-2019.pdf))
 
 * **On the expressive power of user-defined effects: effect handlers, monadic reflection, delimited control** (JFP, ICFP 2017 special issue)  
   by Yannick Forster, Ohad Kammar, Sam Lindley, and Matija Pretnar  
+  ([doi](https://doi.org/10.1017/S0956796819000121))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/0002KLP19.html))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/effmondel-jfp.pdf))
 
 * **Dijkstra Monads for All** (ICFP 2019)  
   by Kenji Maillard, Danel Ahman, Robert Atkey, Guido Martínez, Cătălin Hriţcu, Exequiel Rivas and Éric Tanter  
+  ([doi](https://doi.org/10.1145/3341708))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/MaillardAAMHRT19.html))
   ([pdf](https://arxiv.org/abs/1903.01237))
 
 * **A predicate transformer semantics for effects (Functional Pearl)** (ICFP 2020)  
   by Wouter Swierstra and Anne Baanen  
+  ([doi](https://doi.org/10.1145/3341707))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SwierstraB19.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3341707?download=true))
 
 * **Monad transformers and modular algebraic effects: What binds them together** (Haskell 2019)  
   by Tom Schrijvers, Maciej Piróg, Nicolas Wu, and Mauro Jaskelioff  
+  ([doi](https://doi.org/10.1145/3331545.3342595))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/SchrijversPWJ19.html))
   ([pdf](https://maciejpirog.github.io/papers/what-binds-them-together.pdf))
 
 * **A Hierarchy of Monadic Effects for Program Verification using Equational Reasoning** (MPC 2019)  
   by Reynald Affeldt, David Nowak, and Takafumi Saikawa  
+  ([doi](https://doi.org/10.1007/978-3-030-33636-3_9))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/mpc/AffeldtNS19.html))
   ([pdf](https://hal.science/hal-02359796v1/preview/monae.pdf))
   ([GitHub](https://github.com/affeldt-aist/monae))
 
 * **Handling Local State with Global State** (MPC 2019)  
   by Koen Pauwels, Tom Schrijvers, and Shin-Cheng Mu  
+  ([doi](https://doi.org/10.1007/978-3-030-33636-3_2))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/mpc/PauwelsSM19.html))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2019.pdf))
 
 * **Bisimulations for Delimited-Control Operators** (LMCS 2019)  
   by Dariusz Biernacki, Sergueï Lenglet, and Piotr Polesiuk  
+  ([doi](https://doi.org/10.23638/LMCS-15(2:18)2019))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/lmcs/BiernackiLP19a.html))
   ([pdf](https://lmcs.episciences.org/5508/pdf))
 
 * **Typed equivalence of effect handlers and delimited control** (FSCD 2019)  
   Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
+  ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2019.30))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/rta/PirogPS19.html))
   ([pdf](https://maciejpirog.github.io/papers/typed-equivalence-fscd2019.pdf))
 
 * **Handling Polymorphic Algebraic Effects** (ESOP 2019)  
   Taro Sekiyama and Atsushi Igarashi  
+  ([doi](https://doi.org/10.1007/978-3-030-17184-1_13))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/esop/SekiyamaI19.html))
   ([arxiv](https://arxiv.org/pdf/1811.07332))
 
 * **Extended call-by-push-value: reasoning about effectful programs and evaluation order** (ESOP 2019)  
   by Dylan McDermott and Alan Mycroft  
+  ([doi](https://doi.org/10.1007/978-3-030-17184-1_9))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/esop/McDermottM19.html))
   ([pdf](https://www.cl.cam.ac.uk/~dm606/extended-call-by-push-value.pdf))
 
 * **Abstracting Algebraic Effects** (POPL 2019)  
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
+  ([doi](https://doi.org/10.1145/3290319))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS19.html))
   ([pdf](https://maciejpirog.github.io/papers/biernacki-al-popl19.pdf))
 
 * **Abstraction-Safe Effect Handlers via Tunneling** (POPL 2019)  
   by Yizhou Zhang and Andrew Myers  
+  ([doi](https://doi.org/10.1145/3290318))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/ZhangM19.html))
   ([technical report](https://ecommons.cornell.edu/handle/1813/60202))
 
 * **Behavioural Equivalence via Modalities for Algebraic Effects** (TOPLAS 2019)  
   by Alex Simpson and Niels Voorneveld  
+  ([doi](https://doi.org/10.1145/3363518))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/toplas/SimpsonV20.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3363518))
 
 ### 2018
@@ -654,6 +784,7 @@ in various programming languages.
 * **Factorisation Systems for Logical Relations and Monadic Lifting in Type-and-effect System Semantics** (MFPS 2018)  
   by Ohad Kammar and Dylan McDermott  
   ([doi](https://doi.org/10.1016/j.entcs.2018.11.012))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/KammarM18.html))
 
 * **Functional Programming for Modular Bayesian Inference** (ICFP 2018)  
   by Adam Ścibior, Ohad Kammar, and Zoubin Ghahramani  
@@ -661,23 +792,31 @@ in various programming languages.
 
 * **JEff: Objects for Effect** (Onward 2018)  
   by Pablo Inostroza and Tijs van der Storm  
+  ([doi](https://doi.org/10.1145/3276954.3276955))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/oopsla/InostrozaS18.html))
   ([pdf](https://homepages.cwi.nl/~storm/publications/jeff.pdf))
 
 * **Effect Handlers for the Masses** (OOPSLA 2018)  
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, and Klaus Ostermann  
+  ([doi](https://doi.org/10.1145/3276481))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSO18.html))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3276481))
 
 * **Abstract Nonsense** (FARM 2018)  
   by Junia Gonçalves  
   ([doi](https://doi.org/10.1145/3242903.3242908))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Goncalves18.html))
 
 * **Syntax and Semantics for Operations with Scopes**  (LICS 2018)  
   by Maciej Piróg, Tom Schrijvers, Nicolas Wu, and Mauro Jaskelioff  
+  ([doi](https://doi.org/10.1145/3209108.3209166))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/lics/PirogSWJ18.html))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/lics2018.pdf))
 
 * **First Class Dynamic Effect Handlers: or, Polymorphic Heaps with Dynamic Effect Handlers** (TyDe 2018)  
   by Daan Leijen  
   ([doi](https://doi.org/10.1145/3240719.3241789))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Leijen18.html))
 
 * **Algebraic Effect Handlers with Resources and Deep Finalization** (MSR technical report)  
   by Daan Leijen  
@@ -685,49 +824,69 @@ in various programming languages.
 
 * **Shallow Effect Handlers** (APLAS 2018)  
   by Daniel Hillerström and Sam Lindley  
+  ([doi](https://doi.org/10.1007/978-3-030-02768-1_22))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/HillerstromL18.html))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/shallow-extended.pdf))
 
 * **Versatile Event Correlation with Algebraic Effects** (ICFP 2018)  
   by Oliver Bračevac, Nada Amin, Guido Salvaneschi, Sebastian Erdweg, Patrick Eugster, and Mira Mezini  
+  ([doi](https://doi.org/10.1145/3236762))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BracevacASEEM18.html))
   ([pdf](https://programming-group.com/assets/pdf/papers/2018-Versatile-event-correlation-with-algebraic-effects.pdf))
 
 * **Modular Verification of Programs with Effects and Effect Handlers in Coq** (FM 2018)  
   by Thomas Letan, Yann Régis-Gianas, Pierre Chifflier, and Guillaume Hiet  
+  ([doi](https://doi.org/10.1007/978-3-319-95582-7_20))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/fm/LetanRCH18.html))
   ([metadata](https://hal.inria.fr/hal-01799712))
   ([pdf](https://hal.inria.fr/hal-01799712/document))
 
 * **Explicit Effect Subtyping** (ESOP 2018)  
   by Amr Hany Saleh, Georgios Karachalias, Matija Pretnar, and Tom Schrijvers  
+  ([doi](https://doi.org/10.1007/978-3-319-89884-1_12))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/esop/SalehKPS18.html))
   ([pdf](https://lirias.kuleuven.be/bitstream/123456789/618119/1/esop18-final71.pdf))
   ([pdf with appendix](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/esop2018.pdf))
   ([technical report/extended version](https://lirias.kuleuven.be/bitstream/123456789/616205/1/CW711.pdf))
 
 * **Handle with Care: Relational Interpretation of Algebraic Effects and Handlers** (POPL 2018)  
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
+  ([doi](https://doi.org/10.1145/3158096))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS18.html))
   ([pdf](https://bitbucket.org/pl-uwr/aleff-logrel/downloads/popl18e.pdf))
   ([Coq formalisation](https://bitbucket.org/pl-uwr/aleff-logrel))
 
 * **Handling fibred algebraic effects** (POPL 2018)  
   by Danel Ahman  
+  ([doi](https://doi.org/10.1145/3158095))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/Ahman18.html))
   ([pdf](https://danelahman.github.io/papers/popl18.pdf))
 
 ### 2017
 
 * **Staged Generic Programming** (ICFP 2017)  
   by Jeremy Yallop  
+  ([doi](https://doi.org/10.1145/3110273))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/Yallop17.html))
   ([pdf](https://www.cl.cam.ac.uk/~jdy22/papers/staged-generic-programming.pdf))
 
 * **Concurrent System Programming with Effect Handlers** (TFP 2017)  
   by Stephen Dolan, Spiros Eliopolous, Daniel Hillerström, Anil Madhavapeddy, KC Sivaramakrishnan, Leo White  
+  ([doi](https://doi.org/10.1007/978-3-319-89719-6_6))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/sfp/DolanEHMSW17.html))
   ([pdf](http://kcsrk.info/papers/system_effects_feb_18.pdf))
 
 * **Handlers for Non-Monadic Computations** (IFL 2017)  
   by Ruben P. Pieters, Tom Schrijvers, and Exequiel Rivas  
+  ([doi](https://doi.org/10.1145/3205368.3205372))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ifl/PietersSR17.html))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/ifl2017_post.pdf))
   ([technical report/extended version](https://lirias.kuleuven.be/bitstream/123456789/617988/1/CW713.pdf))
 
 * **Effekt: Extensible Algebraic Effects in Scala** (Scala 2017)  
   by Jonathan Immanuel Brachthäuser and Philipp Schuster  
+  ([doi](https://doi.org/10.1145/3136000.3136007))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/scala/BrachthauserS17.html))
 
 * **Efficient Compilation of Algebraic Effects and Handlers**  
   by Matija Pretnar, Amr Hany Saleh, Axel Faes, and Tom Schrijvers  
@@ -735,20 +894,28 @@ in various programming languages.
 
 * **Structured asynchrony with algebraic effects** (TyDe 2017)  
   by Daan Leijen  
+  ([doi](https://doi.org/10.1145/3122975.3122977))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Leijen17.html))
   ([OpenTOC](http://www.sigplan.org/OpenTOC/tyde17.html))
   ([technical report](https://www.microsoft.com/en-us/research/wp-content/uploads/2017/05/asynceffects-msr-tr-2017-21.pdf))
 
 * **Implementing Algebraic Effects in C (or "Monads for Free in C")** (APLAS 2017)  
   by Daan Leijen  
+  ([doi](https://doi.org/10.1007/978-3-319-71237-6_17))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/Leijen17.html))
   ([technical report](https://www.microsoft.com/en-us/research/wp-content/uploads/2017/06/algeff-in-c-tr-v2.pdf))
   ([GitHub](https://github.com/koka-lang/libhandler))
 
 * **Continuation Passing Style for Effect Handlers** (FSCD 2017)  
   by Daniel Hillerström, Sam Lindley, Robert Atkey, and KC Sivaramakrishnan  
+  ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2017.18))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/rta/HillerstromLAS17.html))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/handlers-cps.pdf))
 
 * **On the expressive power of user-defined effects: Effect handlers, monadic reflection, delimited control** (ICFP 2017)  
   by Yannick Forster, Ohad Kammar, Sam Lindley, and Matija Pretnar  
+  ([doi](https://doi.org/10.1145/3110257))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/0002KLP17.html))
   ([arxiv](https://arxiv.org/pdf/1610.09161))
 
 * **A Generic Approach to Flow-Sensitive Polymorphic Effects** (ECOOP 2017)  
@@ -758,17 +925,20 @@ in various programming languages.
 
 * **Do be do be do** (POPL 2017)  
   by Sam Lindley, Conor McBride, and Craig McLaughlin  
+  ([doi](https://doi.org/10.1145/3009837.3009897))
   ([dblp](https://dblp.uni-trier.de/rec/conf/popl/LindleyMM17.html))
   ([bibtex](https://dblp.uni-trier.de/rec/conf/popl/LindleyMM17.html?view=bibtex))
   ([arxiv](https://arxiv.org/pdf/1611.09259))
 
 * **Type directed compilation of row-typed algebraic effects** (POPL 2017)  
   by Daan Leijen  
+  ([doi](https://doi.org/10.1145/3009837.3009872))
   ([dblp](https://dblp.uni-trier.de/rec/conf/popl/Leijen17.html))
   ([bibtex](https://dblp.uni-trier.de/rec/conf/popl/Leijen17.html?view=bibtex))
 
 * **No value restriction is needed for algebraic effects and handlers** (J. Funct. Program. 2017)  
   by Ohad Kammar and Matija Pretnar  
+  ([doi](https://doi.org/10.1017/S0956796816000320))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/KammarP17.html))
   ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/KammarP17.html?view=bibtex))
   ([arxiv](https://arxiv.org/pdf/1605.06938))
@@ -777,10 +947,14 @@ in various programming languages.
 
 * **Combining Effects and Coeffects via Grading** (ICFP 2016)  
   by Marco Gaboardi, Shin-ya Katsumata, Dominic Orchard, Flavien Breuvart, and Tarmo Uustalu  
+  ([doi](https://doi.org/10.1145/2951913.2951939))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/GaboardiKOBU16.html))
   ([pdf](https://www.cs.kent.ac.uk/people/staff/dao7/publ/combining-effects-and-coeffects-icfp16.pdf))
 
 * **Effects as Sessions, Sessions as Effects** (POPL 2016)  
   by Dominic Orchard and Nobuko Yoshida  
+  ([doi](https://doi.org/10.1145/2837614.2837634))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/popl/OrchardY16.html))
   ([pdf](https://www.cs.kent.ac.uk/people/staff/dao7/publ/popl16-orchard-yoshida.pdf))
 
 * **Effect Systems Revisited -- Control-Flow Algebra and Semantics**  (Semantics, Logics, and Calculi 2016)  
@@ -789,10 +963,14 @@ in various programming languages.
 
 * **Efficient Algebraic Effect Handlers for Prolog** (TPLP/ICLP 2016)  
   by Amr Hany Saleh and Tom Schrijvers  
+  ([doi](https://doi.org/10.1017/S147106841600034X))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/tplp/SalehS16.html))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/iclp2016a.pdf))
 
 * **Eff Directly in OCaml** (ML Workshop 2016)  
   by Oleg Kiselyov and KC Sivaramakrishnan  
+  ([doi](https://doi.org/10.4204/EPTCS.285.2))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-1812-11664.html))
   ([pdf](http://kcsrk.info/papers/caml-eff17.pdf))
   ([extended abstract](http://kcsrk.info/papers/eff_ocaml_ml16.pdf))
 
@@ -802,6 +980,7 @@ in various programming languages.
 
 * **Liberating effects with rows and handlers** (TyDe 2016)  
   by Daniel Hillerström and Sam Lindley  
+  ([doi](https://doi.org/10.1145/2976022.2976033))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/HillerstromL16.html))
   ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/HillerstromL16.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
@@ -814,6 +993,8 @@ in various programming languages.
   
 * **From Monads to Effects and Back** (PADL 2016)  
   by Niki Vazou and Daan Leijen  
+  ([doi](https://doi.org/10.1007/978-3-319-28228-2_11))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/padl/VazouL16.html))
   ([pdf](http://goto.ucsd.edu/~nvazou/koka/padl16.pdf))
 
 ### 2015
@@ -828,6 +1009,8 @@ in various programming languages.
 
 * **Fixing Non-determinism** (IFL 2015)  
   by Alexander Vandenbroucke, Tom Schrijvers, and Frank Piessens  
+  ([doi](https://doi.org/10.1145/2897336.2897342))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ifl/VandenbrouckeSP15.html))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/ifl2015_post.pdf))
 
 * **Customizable Gradual Polymorphic Effects for Scala** (OOPSLA 2015)  
@@ -836,6 +1019,8 @@ in various programming languages.
 
 * **Freer monads, more extensible effects** (Haskell 2015)  
   by Oleg Kiselyov and Hiromi Ishii  
+  ([doi](https://doi.org/10.1145/2804302.2804319))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/KiselyovI15.html))
   ([pdf](http://okmij.org/ftp/Haskell/extensible/more.pdf))
 
 * **Programming with Algebraic Effects and Handlers** (JLAMP 2015)  
@@ -847,6 +1032,8 @@ in various programming languages.
 
 * **Fusion for Free: Efficient Algebraic Effect Handlers** (MPC 2015)  
   by Nicolas Wu and Tom Schrijvers  
+  ([doi](https://doi.org/10.1007/978-3-319-19797-5_15))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/mpc/WuS15.html))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf))
 
 * **Interleaving data and effects** (JFP 2015)  
@@ -859,6 +1046,7 @@ in various programming languages.
 * **Stateful Runners of Effectful Computations**  
   by Tarmo Uustalu  
   ([doi](https://doi.org/10.1016/j.entcs.2015.12.024))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/Uustalu15.html))
 
 ### 2014
 
@@ -868,6 +1056,7 @@ in various programming languages.
 
 * **Algebraic effects and effect handlers for idioms and arrows** (WGP 2014)  
   by Sam Lindley  
+  ([doi](https://doi.org/10.1145/2633628.2633636))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Lindley14.html))
   ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/Lindley14.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/aeia.pdf))
@@ -878,10 +1067,14 @@ in various programming languages.
 
 * **Effect handlers in scope** (Haskell 2014)  
   by Nicolas Wu, Tom Schrijvers and Ralf Hinze  
+  ([doi](https://doi.org/10.1145/2633357.2633358))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/WuSH14.html))
   ([pdf](http://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf))
 
 * **Embedding effect systems in Haskell** (Haskell 2014)  
   by Dominic Orchard and Tomas Petricek  
+  ([doi](https://doi.org/10.1145/2633357.2633368))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/OrchardP14.html))
   ([pdf](https://www.cs.kent.ac.uk/people/staff/dao7/publ/haskell14-effects.pdf))
 
 * **The semantic marriage of monads and effects (extended abstract)** (Unpublished, 2014)  
@@ -910,6 +1103,8 @@ in various programming languages.
 
 * **Programming and reasoning with algebraic effects and dependent types** (ICFP 2013)  
   by Edwin Brady  
+  ([doi](https://doi.org/10.1145/2500365.2500581))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Brady13.html))
   ([pdf](https://www.type-driven.org.uk/edwinb/papers/effects.pdf))
 
 * **The constrained-monad problem** (ICFP 2013)  
@@ -918,11 +1113,15 @@ in various programming languages.
 
 * **Handlers in action** (ICFP 2013)  
   by Ohad Kammar, Sam Lindley and Nicolas Oury  
+  ([doi](https://doi.org/10.1145/2500365.2500590))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/KammarLO13.html))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/handlers.pdf))
   ([GitHub](https://github.com/slindley/effect-handlers))
 
 * **Extensible effects: an alternative to monad transformers** (Haskell 2013)  
   by Oleg Kiselyov, Amr Sabry and Cameron Swords  
+  ([doi](https://doi.org/10.1145/2503778.2503791))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/KiselyovSS13.html))
   ([pdf](https://www.cs.indiana.edu/~sabry/papers/exteff.pdf))
 
 * **JavaUI: Effects for UI Object Access** (ECOOP 2013)  
@@ -941,6 +1140,7 @@ in various programming languages.
 * **Normalization by Evaluation and Algebraic Effects** (MFPS 2013)  
   by Danel Ahman and Sam Staton  
   ([doi](https://doi.org/10.1016/j.entcs.2013.09.007))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/AhmanS13.html))
   ([pdf](https://danel.ahman.ee/papers/mfps13.pdf))
 
 * **The Sequential Semantics of Producer Effect Systems** (POPL 2013)  
@@ -977,11 +1177,15 @@ in various programming languages.
 
 * **Just Do It: Simple Monadic Equational Reasoning** (ICFP 2011)  
   by Jeremy Gibbons and Ralf Hinze
+  ([doi](https://doi.org/10.1145/2034773.2034777))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/GibbonsH11.html))
 
 ### 2010
 
 * **Monad transformers as monoid transformers** (Theor. Comp. Science 2010)  
   by Mauro Jaskelioff and Eugenio Moggi
+  ([doi](https://doi.org/10.1016/j.tcs.2010.09.011))
+  ([dblp](https://dblp.uni-trier.de/rec/journals/tcs/JaskelioffM10.html))
 
 * **The Operational Monad Tutorial** (The Monad Reader, 2010)  
   by Heinrich Apfelmus

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ in various programming languages.
 
 * **An Introduction to Algebraic Effects and Handlers** (MFPS 2015)  
   by Matija Pretnar  
+  ([doi](http://dx.doi.org/10.1016/j.entcs.2015.12.003))
   ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/Pretnar15.html))
   ([bibtex](https://dblp.uni-trier.de/rec/journals/entcs/Pretnar15.html?view=bibtex))
-  ([doi](http://dx.doi.org/10.1016/j.entcs.2015.12.003))
   ([pdf](http://www.eff-lang.org/handlers-tutorial.pdf))
 
 ## Papers
@@ -369,13 +369,13 @@ in various programming languages.
 
 * **A Functional Abstraction of Typed Invocation Contexts** (FSCD 2021)  
   by Youyou Cong, Chiaki Ishio, Kaho Honda, and Kenichi Asai  
-  ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14250/pdf/LIPIcs-FSCD-2021-12.pdf))
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2021.12))
+  ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14250/pdf/LIPIcs-FSCD-2021-12.pdf))
 
 * **Derivation of a Virtual Machine For Four Variants of Delimited-Control Operators** (FSCD 2021)  
   by Maika Fujii and Kenichi Asai  
-  ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14254/pdf/LIPIcs-FSCD-2021-16.pdf))
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2021.16))
+  ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14254/pdf/LIPIcs-FSCD-2021-16.pdf))
 
 * **Contextual Effect Polymorphism Meets Bidirectional Effects (Extended Abstract)** (TyDe 2021)  
   by Kazuki Niimi, Youyou Cong, and Jonathan Immanuel Brachthäuser  
@@ -421,8 +421,8 @@ in various programming languages.
 
 * **Asynchronous Effects** (POPL 2021)  
   by Danel Ahman and Matija Pretnar  
-  ([arxiv](https://arxiv.org/abs/2003.02110))
   ([doi](https://doi.org/10.1145/3434305))
+  ([arxiv](https://arxiv.org/abs/2003.02110))
   ([pdf](https://arxiv.org/pdf/2003.02110.pdf))
 
 ### 2020
@@ -802,15 +802,15 @@ in various programming languages.
 
 * **Liberating effects with rows and handlers** (TyDe 2016)  
   by Daniel Hillerström and Sam Lindley  
-  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/HillerstromL16.html))
   ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/HillerstromL16.html?view=bibtex))
+  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/links-effect.pdf))
 
 * **Dependent Types and Fibred Computational Effects** (FoSSaCS 2016)  
   by Danel Ahman, Neil Ghani, and Gordon Plotkin  
-  ([pdf](https://danelahman.github.io/papers/fossacs16.pdf))
   ([dblp](https://dblp.uni-trier.de/rec/conf/fossacs/AhmanGP16.html))
   ([bibtex](https://dblp.uni-trier.de/rec/conf/fossacs/AhmanGP16.html?view=bibtex))
+  ([pdf](https://danelahman.github.io/papers/fossacs16.pdf))
   
 * **From Monads to Effects and Back** (PADL 2016)  
   by Niki Vazou and Daan Leijen  
@@ -840,10 +840,10 @@ in various programming languages.
 
 * **Programming with Algebraic Effects and Handlers** (JLAMP 2015)  
   by Andrej Bauer and Matija Pretnar  
-  ([arxiv](http://math.andrej.com/wp-content/uploads/2012/03/eff.pdf))
+  ([doi](http://dx.doi.org/10.1016/j.jlamp.2014.02.001))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jlp/BauerP15.html))
   ([bibtex](https://dblp.uni-trier.de/rec/journals/jlp/BauerP15.html?view=bibtex))
-  ([doi](http://dx.doi.org/10.1016/j.jlamp.2014.02.001))
+  ([arxiv](http://math.andrej.com/wp-content/uploads/2012/03/eff.pdf))
 
 * **Fusion for Free: Efficient Algebraic Effect Handlers** (MPC 2015)  
   by Nicolas Wu and Tom Schrijvers  
@@ -851,9 +851,9 @@ in various programming languages.
 
 * **Interleaving data and effects** (JFP 2015)  
   by Robert Atkey and Patricia Johann  
+  ([doi](http://dx.doi.org/10.1017/S0956796815000209))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/AtkeyJ15.html))
   ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/AtkeyJ15.html?view=bibtex))
-  ([doi](http://dx.doi.org/10.1017/S0956796815000209))
   ([pdf](http://bentnib.org/interleaving.pdf))
 
 * **Stateful Runners of Effectful Computations**  
@@ -890,17 +890,17 @@ in various programming languages.
 
 * **Inferring algebraic effects** (LMCS 2014)  
   by Matija Pretnar  
-  ([arxiv](http://arxiv.org/pdf/1312.2334.pdf))
+  ([doi](http://dx.doi.org/10.2168/LMCS-10%283:21%292014))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/Pretnar13.html))
   ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/Pretnar13.html?view=bibtex))
-  ([doi](http://dx.doi.org/10.2168/LMCS-10%283:21%292014))
+  ([arxiv](http://arxiv.org/pdf/1312.2334.pdf))
 
 * **An Effect System for Algebraic Effects and Handlers** (LMCS 2014)  
   by Andrej Bauer and Matija Pretnar  
-  ([arxiv](http://arxiv.org/pdf/1306.6316.pdf))
+  ([doi](http://dx.doi.org/10.2168/LMCS-10%284:9%292014))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/BauerP13.html))
   ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/BauerP13.html?view=bibtex))
-  ([doi](http://dx.doi.org/10.2168/LMCS-10%284:9%292014))
+  ([arxiv](http://arxiv.org/pdf/1306.6316.pdf))
 
 * **Parametric Effect Monads and Semantics of Effect Systems** (POPL 2014)  
   by Shin-ya Katsumata  
@@ -927,16 +927,16 @@ in various programming languages.
 
 * **JavaUI: Effects for UI Object Access** (ECOOP 2013)  
   by Colin S. Gordon, Werner Dietl, Michael D. Ernst and Dan Grossman  
-  ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/GordonDEG13.html))
   ([doi](http://dx.doi.org/10.1007/978-3-642-39038-8_8))
+  ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/GordonDEG13.html))
   ([pdf](https://www.cs.drexel.edu/~csgordon/papers/ecoop13.pdf))
 
 * **Handling algebraic effects** (LMCS 2013)  
   by Gordon Plotkin and Matija Pretnar  
-  ([arxiv](http://arxiv.org/abs/1312.1399))
+  ([doi](http://dx.doi.org/10.2168/LMCS-9%284:23%292013))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/PlotkinP13.html))
   ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/PlotkinP13.html?view=bibtex))
-  ([doi](http://dx.doi.org/10.2168/LMCS-9%284:23%292013))
+  ([arxiv](http://arxiv.org/abs/1312.1399))
 
 * **Normalization by Evaluation and Algebraic Effects** (MFPS 2013)  
   by Danel Ahman and Sam Staton  

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ in various programming languages.
 
 * **Desk**: A statically-typed functional language with an effect system based on set-operation  
   by Ryo Hirayama from Hihaheho Studio  
-  ([GitHub](https://github.com/Hihaheho/Desk)) ([an effects tutorial article](https://github.com/Hihaheho/Desk/blob/main/docs/blog/0002-algebraic-effects.md))
+  ([GitHub](https://github.com/Hihaheho/Desk))
+  ([an effects tutorial article](https://github.com/Hihaheho/Desk/blob/main/docs/blog/0002-algebraic-effects.md))
 
 * **Eff**: programming language with algebraic effects and handlers  
   by Andrej Bauer and Matija Pretnar  
@@ -196,9 +197,9 @@ in various programming languages.
 ### 2017
 
 * **Concurrent Programming with Effect Handlers** (tutorial given at [CUFP](http://cufp.org/2017/c3-daniel-hillerstrom-kc-concurrent-programming-with-effect-handlers.html))  
-   by Daniel Hillerström and KC Sivaramakrishnan  
-   ([www](http://cufp.org/2017/c3-daniel-hillerstrom-kc-concurrent-programming-with-effect-handlers.html))
-   ([GitHub](https://github.com/ocamllabs/ocaml-effects-tutorial))
+  by Daniel Hillerström and KC Sivaramakrishnan  
+  ([www](http://cufp.org/2017/c3-daniel-hillerstrom-kc-concurrent-programming-with-effect-handlers.html))
+  ([GitHub](https://github.com/ocamllabs/ocaml-effects-tutorial))
 
 ### 2015
 
@@ -246,7 +247,6 @@ in various programming languages.
 
 ### 2023
 
-
 * **From Capabilities to Regions: Enabling Efficient Compilation of Lexical Effect Handlers** (OOPSLA 2023)  
   by Marius Müller, Philipp Schuster, Jonathan Lindegaard Starup, Klaus Ostermann, and Jonathan Immanuel Brachthäuser  
   ([doi](https://doi.org/10.1145/3622831))
@@ -287,8 +287,8 @@ in various programming languages.
 
 ### 2022
 
-*  **Category-Graded Algebraic Theories and Effect Handlers** (MFPS 2022)  
-   by Takahiro Sanada  
+* **Category-Graded Algebraic Theories and Effect Handlers** (MFPS 2022)  
+  by Takahiro Sanada  
   ([pdf](https://www.kurims.kyoto-u.ac.jp/~tsanada/papers/mfps2022-cat-graded-preproceedings-extended.pdf))
 
 * **Modular probabilistic models via algebraic effects** (ICFP 2022)  
@@ -357,7 +357,7 @@ in various programming languages.
   ([pdf](https://software.imdea.org/~aleks/icfp21/icfp21.pdf))
 
 * **Reasoning about Effect Interaction by Fusion** (ICFP 2021)  
-  by Zhixuan Yang and Nicolas Wu   
+  by Zhixuan Yang and Nicolas Wu
   ([doi](https://doi.org/10.1145/3473578))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3473578))
   ([extended pdf](https://yangzhixuan.github.io/pdf/fused-reasoning-appendices.pdf))
@@ -506,7 +506,7 @@ in various programming languages.
 
 * **Signature restriction for polymorphic algebraic effects** (ICFP 2020)  
   by Taro Sekiyama, Takeshi Tsukada, and Atsushi Igarashi  
- ([pdf](https://arxiv.org/pdf/2003.08138))
+  ([pdf](https://arxiv.org/pdf/2003.08138))
 
 * **Effects for Efficiency: Asymptotic Speedup with First-Class Control** (ICFP 2020)  
   by Daniel Hillerström, Sam Lindley, and John Longley  
@@ -518,8 +518,8 @@ in various programming languages.
 
 * **Compiling Effect Handlers in Capability-Passing Style** (ICFP 2020)  
   by Philipp Schuster, Jonathan Immanuel Brachthäuser, and Klaus Ostermann  
- ([doi](https://doi.org/10.1145/3408975))
- ([pdf](https://dl.acm.org/doi/pdf/10.1145/3408975))
+  ([doi](https://doi.org/10.1145/3408975))
+  ([pdf](https://dl.acm.org/doi/pdf/10.1145/3408975))
 
 * **Effekt: Capability-passing style for type- and effect-safe, extensible effect handlers in Scala** (JFP 2020)  
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, and Klaus Ostermann  
@@ -559,7 +559,8 @@ in various programming languages.
 
 * **Local Algebraic Effect Theories** (JFP 2020)  
   by Žiga Lukšič and Matija Pretnar  
-  ([doi](https://doi.org/10.1017/S0956796819000212)) ([arxiv](https://arxiv.org/abs/2005.13654))  
+  ([doi](https://doi.org/10.1017/S0956796819000212))
+  ([arxiv](https://arxiv.org/abs/2005.13654))  
 
 * **Explicit Effect Subtyping** (JFP 2020)  
   by Georgios Karachalias, Matija Pretnar, Amr Hany Saleh, Stien Vanderhallen and Tom Schrijvers  
@@ -593,7 +594,8 @@ in various programming languages.
 
 * **A Hierarchy of Monadic Effects for Program Verification using Equational Reasoning** (MPC 2019)  
   by Reynald Affeldt, David Nowak, and Takafumi Saikawa  
-  ([pdf](https://hal.science/hal-02359796v1/preview/monae.pdf)) ([GitHub](https://github.com/affeldt-aist/monae))
+  ([pdf](https://hal.science/hal-02359796v1/preview/monae.pdf))
+  ([GitHub](https://github.com/affeldt-aist/monae))
 
 * **Handling Local State with Global State** (MPC 2019)  
   by Koen Pauwels, Tom Schrijvers, and Shin-Cheng Mu  
@@ -626,7 +628,6 @@ in various programming languages.
 * **Behavioural Equivalence via Modalities for Algebraic Effects** (TOPLAS 2019)  
   by Alex Simpson and Niels Voorneveld  
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3363518))
-
 
 ### 2018
 
@@ -722,7 +723,8 @@ in various programming languages.
 
 * **Handlers for Non-Monadic Computations** (IFL 2017)  
   by Ruben P. Pieters, Tom Schrijvers, and Exequiel Rivas  
-  ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/ifl2017_post.pdf)) ([technical report/extended version](https://lirias.kuleuven.be/bitstream/123456789/617988/1/CW713.pdf))
+  ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/ifl2017_post.pdf))
+  ([technical report/extended version](https://lirias.kuleuven.be/bitstream/123456789/617988/1/CW713.pdf))
 
 * **Effekt: Extensible Algebraic Effects in Scala** (Scala 2017)  
   by Jonathan Immanuel Brachthäuser and Philipp Schuster  
@@ -791,7 +793,8 @@ in various programming languages.
 
 * **Eff Directly in OCaml** (ML Workshop 2016)  
   by Oleg Kiselyov and KC Sivaramakrishnan  
-  ([pdf](http://kcsrk.info/papers/caml-eff17.pdf)) ([extended abstract](http://kcsrk.info/papers/eff_ocaml_ml16.pdf))
+  ([pdf](http://kcsrk.info/papers/caml-eff17.pdf))
+  ([extended abstract](http://kcsrk.info/papers/eff_ocaml_ml16.pdf))
 
 * **Compiling Links Effect Handlers to the OCaml Backend** (ML Workshop 2016)  
   by Daniel Hillerström, Sam Lindley, and KC Sivaramakrishnan  
@@ -903,7 +906,6 @@ in various programming languages.
   by Shin-ya Katsumata  
   ([doi](https://doi.org/10.1145/2535838.2535846))
 
-
 ### 2013
 
 * **Programming and reasoning with algebraic effects and dependent types** (ICFP 2013)  
@@ -916,8 +918,8 @@ in various programming languages.
 
 * **Handlers in action** (ICFP 2013)  
   by Ohad Kammar, Sam Lindley and Nicolas Oury  
-  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/handlers.pdf)) ([GitHub](https://github.com/slindley/effect-handlers))
-
+  ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/handlers.pdf))
+  ([GitHub](https://github.com/slindley/effect-handlers))
 
 * **Extensible effects: an alternative to monad transformers** (Haskell 2013)  
   by Oleg Kiselyov, Amr Sabry and Cameron Swords  
@@ -944,7 +946,6 @@ in various programming languages.
 * **The Sequential Semantics of Producer Effect Systems** (POPL 2013)  
   by Ross Tate  
   ([doi](https://doi.org/10.1145/2429069.2429074))
-
 
 ### 2012
 
@@ -991,16 +992,13 @@ in various programming languages.
   by Gordon Plotkin and Matija Pretnar  
   ([pdf](http://homepages.inf.ed.ac.uk/gdp/publications/Effect_Handlers.pdf))
 
-
 * **Parameterised Notions of Computation** (JFP 2009)  
   by Robert Atkey  
   ([pdf](http://bentnib.org/paramnotions-jfp.pdf))
 
-
 * **Algebras for Parameterised Monads** (CALCO 2009)  
   by Robert Atkey  
   ([pdf](http://bentnib.org/algebras-param-monads.pdf))
-
 
 ### 2008
 
@@ -1128,10 +1126,9 @@ in various programming languages.
 
 ### 1991
 
- * **Notions of computation and monads** (Information and Computation, 93(1), 1991)  
-   by Eugenio Moggi  
-   ([pdf](http://www.disi.unige.it/person/MoggiE/ftp/ic91.pdf))
-
+* **Notions of computation and monads** (Information and Computation, 93(1), 1991)  
+  by Eugenio Moggi  
+  ([pdf](http://www.disi.unige.it/person/MoggiE/ftp/ic91.pdf))
 
 ### 1990
 
@@ -1160,153 +1157,152 @@ in various programming languages.
   by Pierre Jouvelot and David K. Gifford  
   ([doi](https://doi.org/10.1109%2FICCL.1988.13044))
 
-
 ## Theses and Dissertations
 
-  ### 2024
+### 2024
 
-  * **Algebraic Effects and Handlers for Arrows** (PhD Dissertation, Kyoto University)  
-    by Takahiro Sanada  
-    ([pdf](https://www.kurims.kyoto-u.ac.jp/~tsanada/papers/phdthesis.pdf))
+* **Algebraic Effects and Handlers for Arrows** (PhD Dissertation, Kyoto University)  
+  by Takahiro Sanada  
+  ([pdf](https://www.kurims.kyoto-u.ac.jp/~tsanada/papers/phdthesis.pdf))
 
-  ### 2023
+### 2023
 
-  * **Elaine: Elaboration of Higher-Order Effects as First-Class Language Feature** (MSc Dissertation, TU Delft)  
-    by Terts Diepraam  
-    ([pdf](https://repository.tudelft.nl/islandora/object/uuid:f6c38be6-853f-499b-aa4e-cfa2ce219bf5/datastream/OBJ/download))
+* **Elaine: Elaboration of Higher-Order Effects as First-Class Language Feature** (MSc Dissertation, TU Delft)  
+  by Terts Diepraam  
+  ([pdf](https://repository.tudelft.nl/islandora/object/uuid:f6c38be6-853f-499b-aa4e-cfa2ce219bf5/datastream/OBJ/download))
 
-  * **Deriving Effect Handler Semantics** (MSc Dissertation, TU Delft)  
-    by Chris Lemaire  
-    ([pdf](https://repository.tudelft.nl/islandora/object/uuid:414215b8-837d-46d5-952e-bdc5b47e47cc/datastream/OBJ/download))
+* **Deriving Effect Handler Semantics** (MSc Dissertation, TU Delft)  
+  by Chris Lemaire  
+  ([pdf](https://repository.tudelft.nl/islandora/object/uuid:414215b8-837d-46d5-952e-bdc5b47e47cc/datastream/OBJ/download))
 
-  * **Concurrent Structures and Effect Handlers: A Batch Made in Heaven** (BSc Dissertation, Yale NUS College)  
-    by Lee Koon Wen  
-    ([pdf](https://ilyasergey.net/assets/pdf/papers/Koon-Wen-Lee-Capstone.pdf))
+* **Concurrent Structures and Effect Handlers: A Batch Made in Heaven** (BSc Dissertation, Yale NUS College)  
+  by Lee Koon Wen  
+  ([pdf](https://ilyasergey.net/assets/pdf/papers/Koon-Wen-Lee-Capstone.pdf))
 
-  ### 2022
+### 2022
 
-  * **Algebraic Effect Instance Scopes** (BSc Dissertation, University of Wroclaw)  
-    by Patrycja Balik  
-    ([pdf](https://ii.uni.wroc.pl/media/uploads/2022/11/18/balik-patrycja-praca.pdf))
+* **Algebraic Effect Instance Scopes** (BSc Dissertation, University of Wroclaw)  
+  by Patrycja Balik  
+  ([pdf](https://ii.uni.wroc.pl/media/uploads/2022/11/18/balik-patrycja-praca.pdf))
 
-  * **Comprehending Pure Functional Effect Systems** (MSc Dissertation, University of Oxford)  
-    by Daniel Tattan-Birch  
-    ([pdf](https://www.dantb.dev/files/dissertation.pdf))
-    ([Summary post](https://www.dantb.dev/posts/dissertation))
+* **Comprehending Pure Functional Effect Systems** (MSc Dissertation, University of Oxford)  
+  by Daniel Tattan-Birch  
+  ([pdf](https://www.dantb.dev/files/dissertation.pdf))
+  ([Summary post](https://www.dantb.dev/posts/dissertation))
 
-  ### 2021
+### 2021
 
-  * **Foundations for Programming and Implementing Effect Handlers** (PhD Dissertation, The University of Edinburgh)  
-    by Daniel Hillerström  
-    ([pdf](https://dhil.net/research/papers/thesis.pdf))
-    ([GitHub](https://github.com/dhil/phd-dissertation))
+* **Foundations for Programming and Implementing Effect Handlers** (PhD Dissertation, The University of Edinburgh)  
+  by Daniel Hillerström  
+  ([pdf](https://dhil.net/research/papers/thesis.pdf))
+  ([GitHub](https://github.com/dhil/phd-dissertation))
 
-  * **Extending Effekt with Bidirectional Effects** (MSc Dissertation, Tokyo Institute of Technology)  
-    by Kazuki Niimi  
-    ([pdf](https://prg.is.titech.ac.jp/wp-content/uploads/2021/04/2021-03M-niimi.pdf))
+* **Extending Effekt with Bidirectional Effects** (MSc Dissertation, Tokyo Institute of Technology)  
+  by Kazuki Niimi  
+  ([pdf](https://prg.is.titech.ac.jp/wp-content/uploads/2021/04/2021-03M-niimi.pdf))
 
-  ### 2020
+### 2020
 
-  * **Linear Frank** (BSc Dissertation, The University of New South Wales)  
-    by James Treloar  
-    ([pdf](https://people.eng.unimelb.edu.au/rizkallahc/theses/james-treloar-honours-thesis.pdf))
+* **Linear Frank** (BSc Dissertation, The University of New South Wales)  
+  by James Treloar  
+  ([pdf](https://people.eng.unimelb.edu.au/rizkallahc/theses/james-treloar-honours-thesis.pdf))
 
-  * **Applications of Algebraic Effect Theories** (PhD Dissertation, University of Ljubljana)  
-    by Žiga Lukšič  
-    ([pdf](https://repozitorij.uni-lj.si/Dokument.php?id=137124&lang=eng))
+* **Applications of Algebraic Effect Theories** (PhD Dissertation, University of Ljubljana)  
+  by Žiga Lukšič  
+  ([pdf](https://repozitorij.uni-lj.si/Dokument.php?id=137124&lang=eng))
 
-  * **Asynchronous Effect Handling** (MSc Dissertation, The University of Edinburgh)  
-    by Leo Poulson  
-    ([pdf](https://raw.githubusercontent.com/leopoulson/thesis/master/thesis.pdf))
+* **Asynchronous Effect Handling** (MSc Dissertation, The University of Edinburgh)  
+  by Leo Poulson  
+  ([pdf](https://raw.githubusercontent.com/leopoulson/thesis/master/thesis.pdf))
 
-  * **Relational Reasoning for Effects and Handlers** (PhD Dissertation, The University of Edinburgh)  
-    by Craig McLaughlin  
-    ([doi](http://dx.doi.org/10.7488/era/537))
-    ([pdf](https://era.ed.ac.uk/bitstream/handle/1842/37236/McLaughlin2020.pdf?sequence=1&isAllowed=y))
+* **Relational Reasoning for Effects and Handlers** (PhD Dissertation, The University of Edinburgh)  
+  by Craig McLaughlin  
+  ([doi](http://dx.doi.org/10.7488/era/537))
+  ([pdf](https://era.ed.ac.uk/bitstream/handle/1842/37236/McLaughlin2020.pdf?sequence=1&isAllowed=y))
 
-  * **Design and Implementation of Effect Handlers for Object-Oriented Programming Languages** (PhD Dissertation, University of Tübingen)  
-    by Jonathan Immanuel Brachthäuser  
-    ([dblp](https://dblp.uni-trier.de/rec/phd/dnb/Brachthauser20.html))
+* **Design and Implementation of Effect Handlers for Object-Oriented Programming Languages** (PhD Dissertation, University of Tübingen)  
+  by Jonathan Immanuel Brachthäuser  
+  ([dblp](https://dblp.uni-trier.de/rec/phd/dnb/Brachthauser20.html))
 
-  ### 2019
+### 2019
 
-  * **A Type System for Dynamic Instances** (MSc Dissertation, TU Delft)  
-    by Albert ten Napel  
-    ([pdf](https://repository.tudelft.nl/islandora/object/uuid:36d382d8-3ba4-4825-b718-a080b01b0649/datastream/OBJ/download))
+* **A Type System for Dynamic Instances** (MSc Dissertation, TU Delft)  
+  by Albert ten Napel  
+  ([pdf](https://repository.tudelft.nl/islandora/object/uuid:36d382d8-3ba4-4825-b718-a080b01b0649/datastream/OBJ/download))
 
-  * **Efficient Algebraic Effect Handlers** (PhD Dissertation, KU Leuven)  
-    by Amr Hany Saleh  
-    ([pdf](https://lirias.kuleuven.be/retrieve/532832/))
+* **Efficient Algebraic Effect Handlers** (PhD Dissertation, KU Leuven)  
+  by Amr Hany Saleh  
+  ([pdf](https://lirias.kuleuven.be/retrieve/532832/))
 
-  * **Program Equivalence for Algebraic Effects via Modalities** (MSc Dissertation, University of Oxford)  
-    by Cristina Matache  
-    ([pdf](https://homepages.inf.ed.ac.uk/cmatache/documents/m_diss.pdf))
+* **Program Equivalence for Algebraic Effects via Modalities** (MSc Dissertation, University of Oxford)  
+  by Cristina Matache  
+  ([pdf](https://homepages.inf.ed.ac.uk/cmatache/documents/m_diss.pdf))
 
-  * **Defined Algebraic Operations** (PhD Dissertation, University of Birmingham)  
-    by Bram Geron  
-    ([pdf](https://bram.xyz/thesis.pdf))
+* **Defined Algebraic Operations** (PhD Dissertation, University of Birmingham)  
+  by Bram Geron  
+  ([pdf](https://bram.xyz/thesis.pdf))
 
-  ### 2018
+### 2018
 
-  * **Algebraic Subtyping for Algebraic Effects and Handlers** (MSc Dissertation, KU Leuven)  
-    by Alex Faes  
-    ([pdf](https://github.com/TheAxeC/algebraic-subtyping-for-algebraic-effects-and-handlers/blob/master/thesis.pdf))
+* **Algebraic Subtyping for Algebraic Effects and Handlers** (MSc Dissertation, KU Leuven)  
+  by Alex Faes  
+  ([pdf](https://github.com/TheAxeC/algebraic-subtyping-for-algebraic-effects-and-handlers/blob/master/thesis.pdf))
 
-  ### 2017
+### 2017
 
-  * **Distributive Interaction of Algebraic Effects** (PhD Dissertation, University of Oxford)  
-    by Kwok-Ho Cheung  
-    ([pdf](https://ora.ox.ac.uk/objects/uuid:66106628-0a71-4564-bc34-c398db766818/download_file?file_format=pdf&safe_filename=report.pdf&type_of_work=Thesis))
+* **Distributive Interaction of Algebraic Effects** (PhD Dissertation, University of Oxford)  
+  by Kwok-Ho Cheung  
+  ([pdf](https://ora.ox.ac.uk/objects/uuid:66106628-0a71-4564-bc34-c398db766818/download_file?file_format=pdf&safe_filename=report.pdf&type_of_work=Thesis))
 
-  * **Enhancing a Modular Effectful Programming Language** (MSc Dissertation, The University of Edinburgh)  
-    by Lukas Convent  
-    ([pdf](http://lukas.convnet.de/proj/master/thesis.pdf))
+* **Enhancing a Modular Effectful Programming Language** (MSc Dissertation, The University of Edinburgh)  
+  by Lukas Convent  
+  ([pdf](http://lukas.convnet.de/proj/master/thesis.pdf))
 
-  * **Fibred Computational Effects** (PhD Dissertation, The University of Edinburgh)  
-    by Danel Ahman  
-    ([pdf](https://danel.ahman.ee/papers/phd-thesis.pdf))
+* **Fibred Computational Effects** (PhD Dissertation, The University of Edinburgh)  
+  by Danel Ahman  
+  ([pdf](https://danel.ahman.ee/papers/phd-thesis.pdf))
 
-  ### 2016
+### 2016
 
-  * **Compilation of Effect Handlers and their Applications in Concurrency** (MSc Dissertation, The University of Edinburgh)  
-    by Daniel Hillerström  
-    ([pdf](https://www.dhil.net/research/papers/thesis2016.pdf))
+* **Compilation of Effect Handlers and their Applications in Concurrency** (MSc Dissertation, The University of Edinburgh)  
+  by Daniel Hillerström  
+  ([pdf](https://www.dhil.net/research/papers/thesis2016.pdf))
 
-  * **On the expressive power of effect handlers and monadic reflection** (MSc Dissertation, University of Cambridge)  
-    by Yannick Forster  
-    ([pdf](http://www.ps.uni-saarland.de/~forster/downloads/mphil-thesis.pdf))
+* **On the expressive power of effect handlers and monadic reflection** (MSc Dissertation, University of Cambridge)  
+  by Yannick Forster  
+  ([pdf](http://www.ps.uni-saarland.de/~forster/downloads/mphil-thesis.pdf))
 
-  ### 2015
+### 2015
 
-  * **Handlers for Algebraic Effects in Links** (MSc Dissertation, The University of Edinburgh)  
-    by Daniel Hillerström  
-    ([pdf](https://www.dhil.net/research/papers/thesis2015.pdf))
+* **Handlers for Algebraic Effects in Links** (MSc Dissertation, The University of Edinburgh)  
+  by Daniel Hillerström  
+  ([pdf](https://www.dhil.net/research/papers/thesis2015.pdf))
 
-  ### 2010
+### 2010
 
-  * **The Logic and Handling of Algebraic Effects** (PhD Dissertation, The University of Edinburgh)  
-    by Matija Pretnar  
-    ([pdf](https://www.era.lib.ed.ac.uk/bitstream/handle/1842/4611/Pretnar2010.pdf))
+* **The Logic and Handling of Algebraic Effects** (PhD Dissertation, The University of Edinburgh)  
+  by Matija Pretnar  
+  ([pdf](https://www.era.lib.ed.ac.uk/bitstream/handle/1842/4611/Pretnar2010.pdf))
 
-  ### 1996
+### 1996
 
-  * **Controlling Effects** (PhD Dissertation, Carnegie Mellon University)  
-    by Andrzej Filinski  
-    ([dvi.gz](http://hjemmesider.diku.dk/~andrzej/papers/CE.dvi.gz))
-    ([ps.gz](http://hjemmesider.diku.dk/~andrzej/papers/CE.ps.gz))
+* **Controlling Effects** (PhD Dissertation, Carnegie Mellon University)  
+  by Andrzej Filinski  
+  ([dvi.gz](http://hjemmesider.diku.dk/~andrzej/papers/CE.dvi.gz))
+  ([ps.gz](http://hjemmesider.diku.dk/~andrzej/papers/CE.ps.gz))
 
-  ### 1995
+### 1995
 
-  * **Semantic Lego** (PhD Dissertation, Columbia University)  
-    by David Espinosa  
-    ([pdf](https://github.com/davidespinosa01/papers/raw/master/E/Espinosa%20David/espinosa-thesis.pdf))
-    ([pdf slides](https://github.com/davidespinosa01/papers/raw/master/E/Espinosa%20David/espinosa-thesis-slides.pdf))
+* **Semantic Lego** (PhD Dissertation, Columbia University)  
+  by David Espinosa  
+  ([pdf](https://github.com/davidespinosa01/papers/raw/master/E/Espinosa%20David/espinosa-thesis.pdf))
+  ([pdf slides](https://github.com/davidespinosa01/papers/raw/master/E/Espinosa%20David/espinosa-thesis-slides.pdf))
 
-  ### 1987
+### 1987
 
-  * **Types and Effects &mdash; Towards the Integration of Functional and Imperative Programming** (PhD Dissertation, MIT)  
-    by John M. Lucassen  
-    ([pdf](https://apps.dtic.mil/sti/pdfs/ADA186930.pdf))
+* **Types and Effects &mdash; Towards the Integration of Functional and Imperative Programming** (PhD Dissertation, MIT)  
+  by John M. Lucassen  
+  ([pdf](https://apps.dtic.mil/sti/pdfs/ADA186930.pdf))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ in various programming languages.
   by Andrej Bauer  
   ([doi](http://arxiv.org/abs/1807.05923))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-1807-05923.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/abs-1807-05923.html?view=bibtex))
   ([pdf](https://arxiv.org/pdf/1807.05923))  
   (Videos: [1.1](https://www.cs.uoregon.edu/research/summerschool/summer18/lectures/bauer1-1.mp4),
            [1.2](https://www.cs.uoregon.edu/research/summerschool/summer18/lectures/bauer1-2.mp4),
@@ -220,24 +221,28 @@ in various programming languages.
   by Daniel Hillerström, Sam Lindley, and John Longley  
   ([doi](https://doi.org/10.1017/S0956796824000030))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/HillerstromLL24.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/HillerstromLL24.html?view=bibtex))
   ([pdf](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/296879DE2FD96FB6CF388F27978C76E4/S0956796824000030a.pdf/asymptotic-speedup-via-effect-handlers.pdf))
 
 * **Active Objects Based on Algebraic Effects** (Active Object Languages: Current Research Trends)  
   by Martin Andrieux, Ludovic Henrio, and Gabriel Radanne  
   ([doi](https://doi.org/10.1007/978-3-031-51060-1_1))
   ([dblp](https://dblp.uni-trier.de/rec/books/sp/24/AndrieuxHR24.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/books/sp/24/AndrieuxHR24.html?view=bibtex))
   ([pdf](https://hal.science/hal-04388798/document))
 
 * **Soundly Handling Linearity** (POPL 2024)  
   by Wenhao Tang, Daniel Hillerström, Sam Lindley, and J. Garrett Morris  
   ([doi](https://doi.org/10.1145/3632896))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/TangHLM24.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/TangHLM24.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3632896))
 
 * **On Model-Checking Higher-Order Effectful Programs** (POPL 2024)  
   by Ugo Dal Lago and Alexis Ghyselen  
   ([doi](https://doi.org/10.1145/3632929))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/LagoG24.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/LagoG24.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3632929))
   ([pdf (extended version)](https://arxiv.org/abs/2308.16542))
 
@@ -245,12 +250,14 @@ in various programming languages.
   by Cameron Moy, Christos Dimoulas, and Matthias Felleisen  
   ([doi](https://doi.org/10.1145/3632930))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/MoyDF24.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/MoyDF24.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3632930))
 
 * **An Intrinsically Typed Compiler for Algebraic Effect Handlers** (PEPM 2024)  
   by Syouki Tsuyama, Youyou Cong, and Hidehiko Masuhara  
   ([doi](https://doi.org/10.1145/3635800.3636968))
   ([dblp](https://dblp.uni-trier.de/rec/conf/pepm/TsuyamaCM24.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/pepm/TsuyamaCM24.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3635800.3636968))
 
 ### 2023
@@ -259,18 +266,21 @@ in various programming languages.
   by Marius Müller, Philipp Schuster, Jonathan Lindegaard Starup, Klaus Ostermann, and Jonathan Immanuel Brachthäuser  
   ([doi](https://doi.org/10.1145/3622831))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/MullerSSOB23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/MullerSSOB23.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3622831))
 
 * **Continuing WebAssembly with Effect Handlers** (OOPSLA 2023)  
   by Luna Phipps-Costin, Andreas Rossberg, Arjun Guha, Daan Leijen, Daniel Hillerström, KC Sivaramakrishnan, Matija Pretnar, and Sam Lindley  
   ([doi](https://doi.org/10.1145/3622814))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/PhippsCostinRGLHSPL23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/PhippsCostinRGLHSPL23.html?view=bibtex))
   ([arxiv](https://doi.org/10.48550/arXiv.2308.08347))
 
 * **Typed equivalence of labeled effect handlers and labeled delimited control operators** (PPDP 2023)  
   by Kazuki Ikemori, Youyou Cong, and Hidehiko Masuhara  
   ([doi](https://doi.org/10.1145/3610612.3610616))
   ([dblp](https://dblp.uni-trier.de/rec/conf/ppdp/IkemoriCM23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/ppdp/IkemoriCM23.html?view=bibtex))
   ([pdf](https://prg.is.titech.ac.jp/papers/pdf/ppdp2023.pdf))
   ([bibtex](https://dblp.org/rec/conf/ppdp/IkemoriCM23.html?view=bibtex))
 
@@ -278,29 +288,34 @@ in various programming languages.
   by Colin S. Gordon, Chaewon Yun  
   ([doi](https://doi.org/10.1007/978-3-031-44245-2_16))
   ([dblp](https://dblp.uni-trier.de/rec/conf/sas/GordonY23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/sas/GordonY23.html?view=bibtex))
 
 * **A General Fine-Grained Reduction Theory for Effect Handlers** (ICFP 2023)  
   by Filip Sieczkowski, Mateusz Pyzik, and Dariusz Biernacki  
   ([doi](https://doi.org/10.1145/3607848))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SieczkowskiPB23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/SieczkowskiPB23.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3607848))
 
 * **With or Without You: Programming with Effect Exclusion** (ICFP 2023)  
   by Matthew Lutze, Magnus Madsen, Philipp Schuster, and Jonathan Immanuel Brachthäuser  
   ([doi](https://doi.org/10.1145/3607846))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/LutzeMSB23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/LutzeMSB23.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3607846))
 
 * **Hefty Algebras: Modular Elaboration of Higher-Order Algebraic Effects** (POPL 2023)  
   by Casper Bach Poulsen and Cas Van Der Rest  
   ([doi](https://dl.acm.org/doi/abs/10.1145/3571255))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/PoulsenR23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/PoulsenR23.html?view=bibtex))
   ([pdf](http://casperbp.net/store/hefty-algebras.pdf))
 
 * **Towards a Reflection for Effect Handlers** (PEPM 2023)  
   by Youyou Cong and Kenichi Asai  
   ([doi](https://dl.acm.org/doi/abs/10.1145/3571786.3573015))
   ([dblp](https://dblp.uni-trier.de/rec/conf/pepm/CongA23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/pepm/CongA23.html?view=bibtex))
 
 ### 2022
 
@@ -308,54 +323,63 @@ in various programming languages.
   by Takahiro Sanada  
   ([doi](https://doi.org/10.46298/entics.10491))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2212-07015.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/abs-2212-07015.html?view=bibtex))
   ([pdf](https://www.kurims.kyoto-u.ac.jp/~tsanada/papers/mfps2022-cat-graded-preproceedings-extended.pdf))
 
 * **Modular probabilistic models via algebraic effects** (ICFP 2022)  
   by Minh Nguyen, Roly Perera, Meng Wang, and Nicolas Wu  
   ([doi](https://doi.org/10.1145/3547635))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/NguyenPWW22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/NguyenPWW22.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3547635))
 
 * **Automated Temporal Veriﬁcation for Algebraic Effects** (APLAS 2022)  
   by Yahui Song, Darius Foo, and Wei-Ngan Chin  
   ([doi](https://doi.org/10.1007/978-3-031-21037-2_5))
   ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/SongFC22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/aplas/SongFC22.html?view=bibtex))
   ([pdf](https://www.comp.nus.edu.sg/~yahuis/APLAS2022.pdf))
 
 * **An Algebraic Theory for Shared-State Concurrency** (APLAS 2022)  
   by Yotam Dvir, Ohad Kammar, and Ori Lahav  
   ([doi](https://doi.org/10.1007/978-3-031-21037-2_1))
   ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/DvirKL22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/aplas/DvirKL22.html?view=bibtex))
   ([pdf](https://www.cs.tau.ac.il/~orilahav/papers/aplas22full.pdf))
 
 * **First-class Names for Effect Handlers** (OOPSLA 2022)  
   by Ningning Xie, Youyou Cong, Kazuki Ikemori, and Daan Leijen  
   ([doi](https://doi.org/10.1145/3563289))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XieCIL22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/XieCIL22.html?view=bibtex))
   ([pdf](https://xnning.github.io/papers/oopsla22namedh.pdf))
 
 * **High-level effect handlers in C++** (OOPSLA 2022)  
   by Dan Ghica, Sam Lindley, Marcos Maroñas Bravo, and Maciej Piróg  
   ([doi](https://doi.org/10.1145/3563445))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/GhicaLBP22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/GhicaLBP22.html?view=bibtex))
   ([pdf](https://homepages.inf.ed.ac.uk/slindley/papers/cppeff.pdf))
 
 * **Algebraic effects for extensible dynamic semantics** (Journal of Logic, Language and Information)  
   by Julian Grove and Jean-Philippe Bernardy  
   ([doi](https://doi.org/10.1007/s10849-022-09378-7))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jolli/GroveB23.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jolli/GroveB23.html?view=bibtex))
   ([pdf](https://semanticsarchive.net/Archive/TMxNGE3M/algebraic.pdf))
 
 * **A Typed Continuation-Passing Translation for Lexical Effect Handlers** (PLDI 2022)  
   by Philipp Schuster, Jonathan Immanuel Brachthäuser, Marius Müller, and Klaus Ostermann  
   ([doi](https://doi.org/10.1145/3519939.3523710))
   ([dblp](https://dblp.uni-trier.de/rec/conf/pldi/SchusterB0O22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/pldi/SchusterB0O22.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3519939.3523710))
 
 * **Structured Handling of Scoped Effects** (ESOP 2022)  
   by Zhixuan Yang, Marco Paviotti, Nicolas Wu, Birthe van den Berg, and Tom Schrijvers  
   ([doi](https://doi.org/10.1007/978-3-030-99336-8_17))
   ([dblp](https://dblp.uni-trier.de/rec/conf/esop/YangPWBS22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/esop/YangPWBS22.html?view=bibtex))
   ([pdf](https://link.springer.com/content/pdf/10.1007/978-3-030-99336-8_17.pdf))
   ([pdf (extended version)](https://arxiv.org/pdf/2201.10287.pdf))
 
@@ -363,6 +387,7 @@ in various programming languages.
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, Edward Lee, and Aleksander Boruch-Gruszecki  
   ([doi](https://doi.org/10.1145/3527320))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSLB22.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSLB22.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3527320))
 
 ### 2021
@@ -371,12 +396,14 @@ in various programming languages.
   by Georgios Karachalias, Filip Koprivec, Matija Pretnar, and Tom Schrijvers  
   ([doi](https://doi.org/10.1145/3485479))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/KarachaliasKPS21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/KarachaliasKPS21.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3485479))
 
 * **Latent Effects for Resuable Language Components** (APLAS 2021)  
   by Birthe van den Berg, Tom Schrijvers, Casper Bach Poulsen, and Nicolas Wu  
   ([doi](https://doi.org/10.1007/978-3-030-89051-3_11))
   ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/BergSPW21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/aplas/BergSPW21.html?view=bibtex))
   ([arxiv](https://arxiv.org/abs/2108.11155))
   ([pdf (extended version)](https://arxiv.org/pdf/2108.11155.pdf))
 
@@ -388,18 +415,21 @@ in various programming languages.
   by Hashan Punchihewa and Nicolas Wu  
   ([doi](https://doi.org/10.1145/3471874.3472988))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/PunchihewaW21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/PunchihewaW21.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3471874.3472988))
 
 * **Contextual Modal Types for Algebraic Effects and Handlers** (ICFP 2021)  
   by Nikita Zyuzin and Aleksandar Nanevski  
   ([doi](https://doi.org/10.1145/3473580))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/ZyuzinN21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/ZyuzinN21.html?view=bibtex))
   ([pdf](https://software.imdea.org/~aleks/icfp21/icfp21.pdf))
 
 * **Reasoning about Effect Interaction by Fusion** (ICFP 2021)  
   by Zhixuan Yang and Nicolas Wu
   ([doi](https://doi.org/10.1145/3473578))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/YangW21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/YangW21.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3473578))
   ([extended pdf](https://yangzhixuan.github.io/pdf/fused-reasoning-appendices.pdf))
 
@@ -407,18 +437,21 @@ in various programming languages.
   by Ningning Xie and Daan Leijen  
   ([doi](https://doi.org/10.1145/3473576))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XieL21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/XieL21.html?view=bibtex))
   ([pdf](https://xnning.github.io/papers/multip.pdf))
 
 * **A Functional Abstraction of Typed Invocation Contexts** (FSCD 2021)  
   by Youyou Cong, Chiaki Ishio, Kaho Honda, and Kenichi Asai  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2021.12))
   ([dblp](https://dblp.uni-trier.de/rec/conf/fscd/CongIHA21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/fscd/CongIHA21.html?view=bibtex))
   ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14250/pdf/LIPIcs-FSCD-2021-12.pdf))
 
 * **Derivation of a Virtual Machine For Four Variants of Delimited-Control Operators** (FSCD 2021)  
   by Maika Fujii and Kenichi Asai  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2021.16))
   ([dblp](https://dblp.uni-trier.de/rec/conf/fscd/FujiiA21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/fscd/FujiiA21.html?view=bibtex))
   ([pdf](https://drops.dagstuhl.de/opus/volltexte/2021/14254/pdf/LIPIcs-FSCD-2021-16.pdf))
 
 * **Contextual Effect Polymorphism Meets Bidirectional Effects (Extended Abstract)** (TyDe 2021)  
@@ -445,6 +478,7 @@ in various programming languages.
   by KC Sivaramakrishnan, Stephen Dolan, Leo White, Tom Kelly, Sadiq Jaffer, and Anil Madhavapeddy  
   ([doi](https://doi.org/10.1145/3453483.3454039))
   ([dblp](https://dblp.uni-trier.de/rec/conf/pldi/Sivaramakrishnan21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/pldi/Sivaramakrishnan21.html?view=bibtex))
   ([arxiv](https://arxiv.org/abs/2104.00250))
   ([pdf](https://arxiv.org/pdf/2104.00250.pdf))
 
@@ -452,6 +486,7 @@ in various programming languages.
   by Colin S. Gordon  
   ([doi](https://doi.org/10.1145/3450272))
   ([dblp](https://dblp.uni-trier.de/rec/journals/toplas/Gordon21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/toplas/Gordon21.html?view=bibtex))
   ([arxiv](https://arxiv.org/abs/1808.02010))
 
 * **Automatic Differentiation via Effects and Handlers: An Implementation in Frank** (PEPM 2021)  
@@ -466,12 +501,14 @@ in various programming languages.
   by Paulo Emílio de Vilhena and François Pottier  
   ([doi](https://doi.org/10.1145/3434314))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/VilhenaP21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/VilhenaP21.html?view=bibtex))
   ([pdf](https://inria.hal.science/hal-03049514v1/document))
 
 * **Asynchronous Effects** (POPL 2021)  
   by Danel Ahman and Matija Pretnar  
   ([doi](https://doi.org/10.1145/3434305))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/AhmanP21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/AhmanP21.html?view=bibtex))
   ([arxiv](https://arxiv.org/abs/2003.02110))
   ([pdf](https://arxiv.org/pdf/2003.02110.pdf))
 
@@ -481,70 +518,82 @@ in various programming languages.
   by Satoshi Kura  
   ([doi](https://doi.org/10.1007/978-3-030-45231-5_21))
   ([dblp](https://dblp.uni-trier.de/rec/conf/fossacs/Kura20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/fossacs/Kura20.html?view=bibtex))
   ([pdf](https://link.springer.com/content/pdf/10.1007/978-3-030-45231-5_21.pdf))
 
 * **Modular verification of programs with effects and effects handlers** (FAOC 2020)  
   by Thomas Letan, Yann Régis-Gianas, Pierre Chifflier, and Guillaume Hiet  
   ([doi](https://dx.doi.org/10.1007/s00165-020-00523-2))
   ([dblp](https://dblp.uni-trier.de/rec/journals/fac/LetanRCH21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/fac/LetanRCH21.html?view=bibtex))
 
 * **Not by equations alone: reasoning with extensible effects** (JFP 2020)  
   by Oleg Kiselyov, Shin-Cheng Mu, and Amr Sabry  
   ([doi](https://doi.org/10.1017/S0956796820000271))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/KiselyovMS21.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/KiselyovMS21.html?view=bibtex))
   ([pdf](https://www.okmij.org/ftp/Haskell/extensible/denot.pdf))
 
 * **Automatic Reparameterisation of Probabilistic Programs** (ICML 2020)  
   by Maria I. Gorinova, Dave Moore, and Matthew D. Hoffman  
   ([dblp](https://dblp.uni-trier.de/rec/conf/icml/GorinovaMH20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icml/GorinovaMH20.html?view=bibtex))
   ([pdf](http://proceedings.mlr.press/v119/gorinova20a/gorinova20a.pdf))
 
 * **Compiling Symbolic Execution with Staging and Algebraic Effects** (OOPSLA 2020)  
   by Guannan Wei, Oliver Bračevac, Shangyin Tan, and Tiark Rompf  
   ([doi](https://doi.org/10.1145/3428232))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/WeiBTR20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/WeiBTR20.html?view=bibtex))
   ([pdf](https://bracevac.org/assets/pdf/oopsla20.pdf))
 
 * **Composing Effects into Tasks and Workflows** (Haskell 2020)  
   by Yves Parès, Jean-Philippe Bernardy, and Richard A. Eisenberg  
   ([doi](https://doi.org/10.1145/3410242))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/ParesBE20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/ParesBE20.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3406088.3409023))
 
 * **Handling Bidirectional Control Flow** (OOPSLA 2020)  
   Yizhou Zhang, Guido Salvaneschi, and Andrew C. Myers  
   ([doi](https://doi.org/10.1145/3428207))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/ZhangSM20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/ZhangSM20.html?view=bibtex))
   ([pdf](https://www.cs.cornell.edu/andru/papers/ufo/bidirectional-effects.pdf))
 
 * **Designing with Static Capabilities and Effects: Use, Mention, and Invariants** (ECOOP 2020)  
   by Colin S. Gordon  
   ([doi](https://doi.org/10.4230/LIPIcs.ECOOP.2020.10))
   ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/Gordon19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/ecoop/Gordon19.html?view=bibtex))
   ([pdf](https://drops.dagstuhl.de/storage/00lipics/lipics-vol166-ecoop2020/LIPIcs.ECOOP.2020.10/LIPIcs.ECOOP.2020.10.pdf))
 
 * **Lifting Sequential Effects to Control Operators** (ECOOP 2020)  
   by Colin S. Gordon  
   ([doi](https://doi.org/10.4230/LIPIcs.ECOOP.2020.23))
   ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/Gordon19a.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/ecoop/Gordon19a.html?view=bibtex))
   ([pdf](https://drops.dagstuhl.de/storage/00lipics/lipics-vol166-ecoop2020/LIPIcs.ECOOP.2020.23/LIPIcs.ECOOP.2020.23.pdf))
 
 * **Degrading Lists** (PPDP 2020)  
   by Dylan McDermott, Maciej Piróg, and Tarmo Uustalu  
   ([doi](https://doi.org/10.1145/3414080.3414084))
   ([dblp](https://dblp.uni-trier.de/rec/conf/ppdp/McDermottPU20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/ppdp/McDermottPU20.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3414080.3414084))
 
 * **Wasm/k: Delimited Continuations for WebAssembly** (DLS 2020)  
   by Donald Pinckney, Arjun Guha, and Yuriy Brun  
   ([doi](https://doi.org/10.1145/3426422.3426978))
   ([dblp](https://dblp.uni-trier.de/rec/conf/dls/PinckneyGB20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/dls/PinckneyGB20.html?view=bibtex))
   ([pdf](https://wasmk.github.io/FullVersion.pdf))
 
 * **A Complete Normal-Form Bisimilarity for Algebraic Effects and Handlers** (FSCD 2020)  
   by Dariusz Biernacki, Sergueï Lenglet, and Piotr Polesiuk  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2020.7))
   ([dblp](https://dblp.uni-trier.de/rec/conf/fscd/BiernackiLP20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/fscd/BiernackiLP20.html?view=bibtex))
   ([pdf](https://drops.dagstuhl.de/opus/volltexte/2020/12329/pdf/LIPIcs-FSCD-2020-7.pdf))
 
 * **A Reflection on Continuation-Composing Style** (FSCD 2020)  
@@ -556,120 +605,140 @@ in various programming languages.
   by Ningning Xie and Daan Leijen  
   ([doi](https://doi.org/10.1145/3406088.3409022))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/XieL20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/XieL20.html?view=bibtex))
   ([pdf](https://www.microsoft.com/en-us/research/uploads/prod/2020/07/effev.pdf))
 
 * **Effects as capabilities: effect handlers and lightweight effect polymorphism** (OOPSLA 2020)  
   by Jonathan Brachthäuser, Philipp Schuster, and Klaus Ostermann  
   ([doi](https://doi.org/10.1145/3428194))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSO20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSO20.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3428194))
 
 * **One-shot Algebraic Effects as Coroutines** (TFP 2020)  
   by Satoru Kawahara and Yukiyoshi Kameyama  
   ([doi](https://doi.org/10.1007/978-3-030-57761-2_8))
   ([dblp](https://dblp.uni-trier.de/rec/conf/sfp/KawaharaK20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/sfp/KawaharaK20.html?view=bibtex))
   ([pdf](http://logic.cs.tsukuba.ac.jp/~sat/pdf/tfp2020.pdf))
 
 * **Generalized Monoidal Effects And Handlers** (JFP 2020)  
   by Ruben P. Pieters, Exequiel Rivas, and Tom Schrijvers  
   ([doi](https://doi.org/10.1017/S0956796820000106))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/PietersRS20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/PietersRS20.html?view=bibtex))
   ([pdf](https://rubenpieters.github.io/assets/papers/JFP20-handlers.pdf))
 
 * **Signature restriction for polymorphic algebraic effects** (ICFP 2020)  
   by Taro Sekiyama, Takeshi Tsukada, and Atsushi Igarashi  
   ([doi](https://doi.org/10.1145/3408999))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SekiyamaTI20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/SekiyamaTI20.html?view=bibtex))
   ([pdf](https://arxiv.org/pdf/2003.08138))
 
 * **Effects for Efficiency: Asymptotic Speedup with First-Class Control** (ICFP 2020)  
   by Daniel Hillerström, Sam Lindley, and John Longley  
   ([doi](https://doi.org/10.1145/3408982))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/HillerstromLL20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/HillerstromLL20.html?view=bibtex))
   ([arxiv](https://arxiv.org/abs/2007.00605))
 
 * **Effect Handlers, Evidently** (ICFP 2020)  
   by Ningning Xie, Jonathan Immanuel Brachthäuser, Daniel Hillerström, Philipp Schuster, and Daan Leijen  
   ([doi](https://doi.org/10.1145/3408981))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XieBHSL20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/XieBHSL20.html?view=bibtex))
   ([pdf](https://www.dhil.net/research/papers/effect_handlers_evidently-extended-icfp2020.pdf))
 
 * **Compiling Effect Handlers in Capability-Passing Style** (ICFP 2020)  
   by Philipp Schuster, Jonathan Immanuel Brachthäuser, and Klaus Ostermann  
   ([doi](https://doi.org/10.1145/3408975))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SchusterBO20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/SchusterBO20.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3408975))
 
 * **Effekt: Capability-passing style for type- and effect-safe, extensible effect handlers in Scala** (JFP 2020)  
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, and Klaus Ostermann  
   ([doi](https://doi.org/10.1017/S0956796820000027))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/BrachthauserSO20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/BrachthauserSO20.html?view=bibtex))
   ([pdf](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/A19680B18FB74AD95F8D83BC4B097D4F/S0956796820000027a.pdf/effekt_capabilitypassing_style_for_type_and_effectsafe_extensible_effect_handlers_in_scala.pdf))
 
 * **Doo bee doo bee doo** (JFP 2020)  
   by Lukas Convent, Sam Lindley, Conor McBride, and Craig McLaughlin  
   ([doi](https://doi.org/10.1017/S0956796820000039))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/ConventLMM20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/ConventLMM20.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/frankly-jfp.pdf))
 
 * **Effect handlers via generalised continuations** (JFP 2020)  
   by Daniel Hillerström, Sam Lindley, and Robert Atkey  
   ([doi](https://doi.org/10.1017/S0956796820000040))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/HillerstromLA20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/HillerstromLA20.html?view=bibtex))
   ([pdf](https://dhil.net/research/papers/generalised_continuations-jfp2020.pdf))
 
 * **Runners in action** (ESOP 2020)  
   by Danel Ahman and Andrej Bauer  
   ([doi](https://doi.org/10.1007/978-3-030-44914-8_2))
   ([dblp](https://dblp.uni-trier.de/rec/conf/esop/AhmanB20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/esop/AhmanB20.html?view=bibtex))
   ([arxiv](https://arxiv.org/pdf/1910.11629.pdf))
 
 * **Interaction Trees: Representing Recursive and Impure Programs in Coq** (POPL 2020)  
   by Li-yao Xia, Yannick Zakowski, Paul He, Chung-Kil Hur, Gregory Malecha, Benjamin C. Pierce, Steve Zdancewic  
   ([doi](https://doi.org/10.1145/3371119))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/XiaZHHMPZ20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/XiaZHHMPZ20.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3371119?download=true))
 
 * **Binders by Day, Labels by Night: Effect Instances via Lexically Scoped Handlers** (POPL 2020)  
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
   ([doi](https://doi.org/10.1145/3371116))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS20.html?view=bibtex))
   ([pdf](https://maciejpirog.github.io/papers/binders-labels.pdf))
 
 * **Combining predicate transformer semantics for effects: a case study in parsing regular languages** (MSFP 2020)  
   by Anne Baanen and Wouter Swierstra  
   ([doi](https://doi.org/10.4204/EPTCS.317.3))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2005-00197.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/abs-2005-00197.html?view=bibtex))
   ([pdf](https://arxiv.org/pdf/2005.00197v1.pdf))  
 
 * **From Equations to Distinctions: Two Interpretations of Effectful Computations** (MSFP 2020)  
   by Niels Voorneveld  
   ([doi](https://doi.org/10.4204/EPTCS.317.1))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2005-00196.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/abs-2005-00196.html?view=bibtex))
   ([pdf](https://arxiv.org/pdf/2005.00196.pdf))  
   
 * **Unifying graded and parameterised monads** (MSFP 2020)  
   by Dominic Orchard, Philip Wadler and Harley Eades III  
   ([doi](https://doi.org/10.4204/EPTCS.317.2))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-2001-10274.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/abs-2001-10274.html?view=bibtex))
   ([pdf](https://arxiv.org/pdf/2001.10274.pdf))  
 
 * **Local Algebraic Effect Theories** (JFP 2020)  
   by Žiga Lukšič and Matija Pretnar  
   ([doi](https://doi.org/10.1017/S0956796819000212))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/LuksicP20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/LuksicP20.html?view=bibtex))
   ([arxiv](https://arxiv.org/abs/2005.13654))  
 
 * **Explicit Effect Subtyping** (JFP 2020)  
   by Georgios Karachalias, Matija Pretnar, Amr Hany Saleh, Stien Vanderhallen and Tom Schrijvers  
   ([doi](https://doi.org/10.1017/S0956796820000131))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/KarachaliasPSVS20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/KarachaliasPSVS20.html?view=bibtex))
   ([arxiv](https://arxiv.org/abs/2005.13814))  
 
 * **The Fire Triangle: How to Mix Substitution, Dependent Elimination, and Effects** (POPL 2020)  
   by Pierre-Marie Pédrot and Nicolas Tabareau  
   ([doi](https://doi.org/10.1145/3371126))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/PedrotT20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/PedrotT20.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3371126))
 
 ### 2019
@@ -678,36 +747,42 @@ in various programming languages.
   by Cristina Matache and Sam Staton  
   ([doi](https://doi.org/10.1007/978-3-030-17127-8_22))
   ([dblp](https://dblp.uni-trier.de/rec/conf/fossacs/MatacheS19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/fossacs/MatacheS19.html?view=bibtex))
   ([pdf](http://www.cs.ox.ac.uk/people/samuel.staton/papers/fossacs-2019.pdf))
 
 * **On the expressive power of user-defined effects: effect handlers, monadic reflection, delimited control** (JFP, ICFP 2017 special issue)  
   by Yannick Forster, Ohad Kammar, Sam Lindley, and Matija Pretnar  
   ([doi](https://doi.org/10.1017/S0956796819000121))
   ([dblp](https://dblp.uni-trier.de/rec/journals/jfp/0002KLP19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/jfp/0002KLP19.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/effmondel-jfp.pdf))
 
 * **Dijkstra Monads for All** (ICFP 2019)  
   by Kenji Maillard, Danel Ahman, Robert Atkey, Guido Martínez, Cătălin Hriţcu, Exequiel Rivas and Éric Tanter  
   ([doi](https://doi.org/10.1145/3341708))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/MaillardAAMHRT19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/MaillardAAMHRT19.html?view=bibtex))
   ([pdf](https://arxiv.org/abs/1903.01237))
 
 * **A predicate transformer semantics for effects (Functional Pearl)** (ICFP 2020)  
   by Wouter Swierstra and Anne Baanen  
   ([doi](https://doi.org/10.1145/3341707))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/SwierstraB19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/SwierstraB19.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3341707?download=true))
 
 * **Monad transformers and modular algebraic effects: What binds them together** (Haskell 2019)  
   by Tom Schrijvers, Maciej Piróg, Nicolas Wu, and Mauro Jaskelioff  
   ([doi](https://doi.org/10.1145/3331545.3342595))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/SchrijversPWJ19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/SchrijversPWJ19.html?view=bibtex))
   ([pdf](https://maciejpirog.github.io/papers/what-binds-them-together.pdf))
 
 * **A Hierarchy of Monadic Effects for Program Verification using Equational Reasoning** (MPC 2019)  
   by Reynald Affeldt, David Nowak, and Takafumi Saikawa  
   ([doi](https://doi.org/10.1007/978-3-030-33636-3_9))
   ([dblp](https://dblp.uni-trier.de/rec/conf/mpc/AffeldtNS19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/mpc/AffeldtNS19.html?view=bibtex))
   ([pdf](https://hal.science/hal-02359796v1/preview/monae.pdf))
   ([GitHub](https://github.com/affeldt-aist/monae))
 
@@ -715,48 +790,56 @@ in various programming languages.
   by Koen Pauwels, Tom Schrijvers, and Shin-Cheng Mu  
   ([doi](https://doi.org/10.1007/978-3-030-33636-3_2))
   ([dblp](https://dblp.uni-trier.de/rec/conf/mpc/PauwelsSM19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/mpc/PauwelsSM19.html?view=bibtex))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2019.pdf))
 
 * **Bisimulations for Delimited-Control Operators** (LMCS 2019)  
   by Dariusz Biernacki, Sergueï Lenglet, and Piotr Polesiuk  
   ([doi](https://doi.org/10.23638/LMCS-15(2:18)2019))
   ([dblp](https://dblp.uni-trier.de/rec/journals/lmcs/BiernackiLP19a.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/lmcs/BiernackiLP19a.html?view=bibtex))
   ([pdf](https://lmcs.episciences.org/5508/pdf))
 
 * **Typed equivalence of effect handlers and delimited control** (FSCD 2019)  
   Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2019.30))
   ([dblp](https://dblp.uni-trier.de/rec/conf/rta/PirogPS19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/rta/PirogPS19.html?view=bibtex))
   ([pdf](https://maciejpirog.github.io/papers/typed-equivalence-fscd2019.pdf))
 
 * **Handling Polymorphic Algebraic Effects** (ESOP 2019)  
   Taro Sekiyama and Atsushi Igarashi  
   ([doi](https://doi.org/10.1007/978-3-030-17184-1_13))
   ([dblp](https://dblp.uni-trier.de/rec/conf/esop/SekiyamaI19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/esop/SekiyamaI19.html?view=bibtex))
   ([arxiv](https://arxiv.org/pdf/1811.07332))
 
 * **Extended call-by-push-value: reasoning about effectful programs and evaluation order** (ESOP 2019)  
   by Dylan McDermott and Alan Mycroft  
   ([doi](https://doi.org/10.1007/978-3-030-17184-1_9))
   ([dblp](https://dblp.uni-trier.de/rec/conf/esop/McDermottM19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/esop/McDermottM19.html?view=bibtex))
   ([pdf](https://www.cl.cam.ac.uk/~dm606/extended-call-by-push-value.pdf))
 
 * **Abstracting Algebraic Effects** (POPL 2019)  
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
   ([doi](https://doi.org/10.1145/3290319))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS19.html?view=bibtex))
   ([pdf](https://maciejpirog.github.io/papers/biernacki-al-popl19.pdf))
 
 * **Abstraction-Safe Effect Handlers via Tunneling** (POPL 2019)  
   by Yizhou Zhang and Andrew Myers  
   ([doi](https://doi.org/10.1145/3290318))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/ZhangM19.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/ZhangM19.html?view=bibtex))
   ([technical report](https://ecommons.cornell.edu/handle/1813/60202))
 
 * **Behavioural Equivalence via Modalities for Algebraic Effects** (TOPLAS 2019)  
   by Alex Simpson and Niels Voorneveld  
   ([doi](https://doi.org/10.1145/3363518))
   ([dblp](https://dblp.uni-trier.de/rec/journals/toplas/SimpsonV20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/toplas/SimpsonV20.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3363518))
 
 ### 2018
@@ -785,6 +868,7 @@ in various programming languages.
   by Ohad Kammar and Dylan McDermott  
   ([doi](https://doi.org/10.1016/j.entcs.2018.11.012))
   ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/KammarM18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/entcs/KammarM18.html?view=bibtex))
 
 * **Functional Programming for Modular Bayesian Inference** (ICFP 2018)  
   by Adam Ścibior, Ohad Kammar, and Zoubin Ghahramani  
@@ -794,29 +878,34 @@ in various programming languages.
   by Pablo Inostroza and Tijs van der Storm  
   ([doi](https://doi.org/10.1145/3276954.3276955))
   ([dblp](https://dblp.uni-trier.de/rec/conf/oopsla/InostrozaS18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/oopsla/InostrozaS18.html?view=bibtex))
   ([pdf](https://homepages.cwi.nl/~storm/publications/jeff.pdf))
 
 * **Effect Handlers for the Masses** (OOPSLA 2018)  
   by Jonathan Immanuel Brachthäuser, Philipp Schuster, and Klaus Ostermann  
   ([doi](https://doi.org/10.1145/3276481))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSO18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/BrachthauserSO18.html?view=bibtex))
   ([pdf](https://dl.acm.org/doi/pdf/10.1145/3276481))
 
 * **Abstract Nonsense** (FARM 2018)  
   by Junia Gonçalves  
   ([doi](https://doi.org/10.1145/3242903.3242908))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Goncalves18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/Goncalves18.html?view=bibtex))
 
 * **Syntax and Semantics for Operations with Scopes**  (LICS 2018)  
   by Maciej Piróg, Tom Schrijvers, Nicolas Wu, and Mauro Jaskelioff  
   ([doi](https://doi.org/10.1145/3209108.3209166))
   ([dblp](https://dblp.uni-trier.de/rec/conf/lics/PirogSWJ18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/lics/PirogSWJ18.html?view=bibtex))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/lics2018.pdf))
 
 * **First Class Dynamic Effect Handlers: or, Polymorphic Heaps with Dynamic Effect Handlers** (TyDe 2018)  
   by Daan Leijen  
   ([doi](https://doi.org/10.1145/3240719.3241789))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Leijen18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/Leijen18.html?view=bibtex))
 
 * **Algebraic Effect Handlers with Resources and Deep Finalization** (MSR technical report)  
   by Daan Leijen  
@@ -826,18 +915,21 @@ in various programming languages.
   by Daniel Hillerström and Sam Lindley  
   ([doi](https://doi.org/10.1007/978-3-030-02768-1_22))
   ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/HillerstromL18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/aplas/HillerstromL18.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/shallow-extended.pdf))
 
 * **Versatile Event Correlation with Algebraic Effects** (ICFP 2018)  
   by Oliver Bračevac, Nada Amin, Guido Salvaneschi, Sebastian Erdweg, Patrick Eugster, and Mira Mezini  
   ([doi](https://doi.org/10.1145/3236762))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BracevacASEEM18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/BracevacASEEM18.html?view=bibtex))
   ([pdf](https://programming-group.com/assets/pdf/papers/2018-Versatile-event-correlation-with-algebraic-effects.pdf))
 
 * **Modular Verification of Programs with Effects and Effect Handlers in Coq** (FM 2018)  
   by Thomas Letan, Yann Régis-Gianas, Pierre Chifflier, and Guillaume Hiet  
   ([doi](https://doi.org/10.1007/978-3-319-95582-7_20))
   ([dblp](https://dblp.uni-trier.de/rec/conf/fm/LetanRCH18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/fm/LetanRCH18.html?view=bibtex))
   ([metadata](https://hal.inria.fr/hal-01799712))
   ([pdf](https://hal.inria.fr/hal-01799712/document))
 
@@ -845,6 +937,7 @@ in various programming languages.
   by Amr Hany Saleh, Georgios Karachalias, Matija Pretnar, and Tom Schrijvers  
   ([doi](https://doi.org/10.1007/978-3-319-89884-1_12))
   ([dblp](https://dblp.uni-trier.de/rec/conf/esop/SalehKPS18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/esop/SalehKPS18.html?view=bibtex))
   ([pdf](https://lirias.kuleuven.be/bitstream/123456789/618119/1/esop18-final71.pdf))
   ([pdf with appendix](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/esop2018.pdf))
   ([technical report/extended version](https://lirias.kuleuven.be/bitstream/123456789/616205/1/CW711.pdf))
@@ -853,6 +946,7 @@ in various programming languages.
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
   ([doi](https://doi.org/10.1145/3158096))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/BiernackiPPS18.html?view=bibtex))
   ([pdf](https://bitbucket.org/pl-uwr/aleff-logrel/downloads/popl18e.pdf))
   ([Coq formalisation](https://bitbucket.org/pl-uwr/aleff-logrel))
 
@@ -860,6 +954,7 @@ in various programming languages.
   by Danel Ahman  
   ([doi](https://doi.org/10.1145/3158095))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/Ahman18.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/Ahman18.html?view=bibtex))
   ([pdf](https://danelahman.github.io/papers/popl18.pdf))
 
 ### 2017
@@ -868,18 +963,21 @@ in various programming languages.
   by Jeremy Yallop  
   ([doi](https://doi.org/10.1145/3110273))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/Yallop17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/Yallop17.html?view=bibtex))
   ([pdf](https://www.cl.cam.ac.uk/~jdy22/papers/staged-generic-programming.pdf))
 
 * **Concurrent System Programming with Effect Handlers** (TFP 2017)  
   by Stephen Dolan, Spiros Eliopolous, Daniel Hillerström, Anil Madhavapeddy, KC Sivaramakrishnan, Leo White  
   ([doi](https://doi.org/10.1007/978-3-319-89719-6_6))
   ([dblp](https://dblp.uni-trier.de/rec/conf/sfp/DolanEHMSW17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/sfp/DolanEHMSW17.html?view=bibtex))
   ([pdf](http://kcsrk.info/papers/system_effects_feb_18.pdf))
 
 * **Handlers for Non-Monadic Computations** (IFL 2017)  
   by Ruben P. Pieters, Tom Schrijvers, and Exequiel Rivas  
   ([doi](https://doi.org/10.1145/3205368.3205372))
   ([dblp](https://dblp.uni-trier.de/rec/conf/ifl/PietersSR17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/ifl/PietersSR17.html?view=bibtex))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/ifl2017_post.pdf))
   ([technical report/extended version](https://lirias.kuleuven.be/bitstream/123456789/617988/1/CW713.pdf))
 
@@ -887,6 +985,7 @@ in various programming languages.
   by Jonathan Immanuel Brachthäuser and Philipp Schuster  
   ([doi](https://doi.org/10.1145/3136000.3136007))
   ([dblp](https://dblp.uni-trier.de/rec/conf/scala/BrachthauserS17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/scala/BrachthauserS17.html?view=bibtex))
 
 * **Efficient Compilation of Algebraic Effects and Handlers**  
   by Matija Pretnar, Amr Hany Saleh, Axel Faes, and Tom Schrijvers  
@@ -896,6 +995,7 @@ in various programming languages.
   by Daan Leijen  
   ([doi](https://doi.org/10.1145/3122975.3122977))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Leijen17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/Leijen17.html?view=bibtex))
   ([OpenTOC](http://www.sigplan.org/OpenTOC/tyde17.html))
   ([technical report](https://www.microsoft.com/en-us/research/wp-content/uploads/2017/05/asynceffects-msr-tr-2017-21.pdf))
 
@@ -903,6 +1003,7 @@ in various programming languages.
   by Daan Leijen  
   ([doi](https://doi.org/10.1007/978-3-319-71237-6_17))
   ([dblp](https://dblp.uni-trier.de/rec/conf/aplas/Leijen17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/aplas/Leijen17.html?view=bibtex))
   ([technical report](https://www.microsoft.com/en-us/research/wp-content/uploads/2017/06/algeff-in-c-tr-v2.pdf))
   ([GitHub](https://github.com/koka-lang/libhandler))
 
@@ -910,12 +1011,14 @@ in various programming languages.
   by Daniel Hillerström, Sam Lindley, Robert Atkey, and KC Sivaramakrishnan  
   ([doi](https://doi.org/10.4230/LIPIcs.FSCD.2017.18))
   ([dblp](https://dblp.uni-trier.de/rec/conf/rta/HillerstromLAS17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/rta/HillerstromLAS17.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/handlers-cps.pdf))
 
 * **On the expressive power of user-defined effects: Effect handlers, monadic reflection, delimited control** (ICFP 2017)  
   by Yannick Forster, Ohad Kammar, Sam Lindley, and Matija Pretnar  
   ([doi](https://doi.org/10.1145/3110257))
   ([dblp](https://dblp.uni-trier.de/rec/journals/pacmpl/0002KLP17.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/pacmpl/0002KLP17.html?view=bibtex))
   ([arxiv](https://arxiv.org/pdf/1610.09161))
 
 * **A Generic Approach to Flow-Sensitive Polymorphic Effects** (ECOOP 2017)  
@@ -949,12 +1052,14 @@ in various programming languages.
   by Marco Gaboardi, Shin-ya Katsumata, Dominic Orchard, Flavien Breuvart, and Tarmo Uustalu  
   ([doi](https://doi.org/10.1145/2951913.2951939))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/GaboardiKOBU16.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/GaboardiKOBU16.html?view=bibtex))
   ([pdf](https://www.cs.kent.ac.uk/people/staff/dao7/publ/combining-effects-and-coeffects-icfp16.pdf))
 
 * **Effects as Sessions, Sessions as Effects** (POPL 2016)  
   by Dominic Orchard and Nobuko Yoshida  
   ([doi](https://doi.org/10.1145/2837614.2837634))
   ([dblp](https://dblp.uni-trier.de/rec/conf/popl/OrchardY16.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/popl/OrchardY16.html?view=bibtex))
   ([pdf](https://www.cs.kent.ac.uk/people/staff/dao7/publ/popl16-orchard-yoshida.pdf))
 
 * **Effect Systems Revisited -- Control-Flow Algebra and Semantics**  (Semantics, Logics, and Calculi 2016)  
@@ -965,12 +1070,14 @@ in various programming languages.
   by Amr Hany Saleh and Tom Schrijvers  
   ([doi](https://doi.org/10.1017/S147106841600034X))
   ([dblp](https://dblp.uni-trier.de/rec/journals/tplp/SalehS16.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/tplp/SalehS16.html?view=bibtex))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/iclp2016a.pdf))
 
 * **Eff Directly in OCaml** (ML Workshop 2016)  
   by Oleg Kiselyov and KC Sivaramakrishnan  
   ([doi](https://doi.org/10.4204/EPTCS.285.2))
   ([dblp](https://dblp.uni-trier.de/rec/journals/corr/abs-1812-11664.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/corr/abs-1812-11664.html?view=bibtex))
   ([pdf](http://kcsrk.info/papers/caml-eff17.pdf))
   ([extended abstract](http://kcsrk.info/papers/eff_ocaml_ml16.pdf))
 
@@ -995,6 +1102,7 @@ in various programming languages.
   by Niki Vazou and Daan Leijen  
   ([doi](https://doi.org/10.1007/978-3-319-28228-2_11))
   ([dblp](https://dblp.uni-trier.de/rec/conf/padl/VazouL16.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/padl/VazouL16.html?view=bibtex))
   ([pdf](http://goto.ucsd.edu/~nvazou/koka/padl16.pdf))
 
 ### 2015
@@ -1011,6 +1119,7 @@ in various programming languages.
   by Alexander Vandenbroucke, Tom Schrijvers, and Frank Piessens  
   ([doi](https://doi.org/10.1145/2897336.2897342))
   ([dblp](https://dblp.uni-trier.de/rec/conf/ifl/VandenbrouckeSP15.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/ifl/VandenbrouckeSP15.html?view=bibtex))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/ifl2015_post.pdf))
 
 * **Customizable Gradual Polymorphic Effects for Scala** (OOPSLA 2015)  
@@ -1021,6 +1130,7 @@ in various programming languages.
   by Oleg Kiselyov and Hiromi Ishii  
   ([doi](https://doi.org/10.1145/2804302.2804319))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/KiselyovI15.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/KiselyovI15.html?view=bibtex))
   ([pdf](http://okmij.org/ftp/Haskell/extensible/more.pdf))
 
 * **Programming with Algebraic Effects and Handlers** (JLAMP 2015)  
@@ -1034,6 +1144,7 @@ in various programming languages.
   by Nicolas Wu and Tom Schrijvers  
   ([doi](https://doi.org/10.1007/978-3-319-19797-5_15))
   ([dblp](https://dblp.uni-trier.de/rec/conf/mpc/WuS15.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/mpc/WuS15.html?view=bibtex))
   ([pdf](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf))
 
 * **Interleaving data and effects** (JFP 2015)  
@@ -1047,6 +1158,7 @@ in various programming languages.
   by Tarmo Uustalu  
   ([doi](https://doi.org/10.1016/j.entcs.2015.12.024))
   ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/Uustalu15.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/entcs/Uustalu15.html?view=bibtex))
 
 ### 2014
 
@@ -1069,12 +1181,14 @@ in various programming languages.
   by Nicolas Wu, Tom Schrijvers and Ralf Hinze  
   ([doi](https://doi.org/10.1145/2633357.2633358))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/WuSH14.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/WuSH14.html?view=bibtex))
   ([pdf](http://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf))
 
 * **Embedding effect systems in Haskell** (Haskell 2014)  
   by Dominic Orchard and Tomas Petricek  
   ([doi](https://doi.org/10.1145/2633357.2633368))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/OrchardP14.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/OrchardP14.html?view=bibtex))
   ([pdf](https://www.cs.kent.ac.uk/people/staff/dao7/publ/haskell14-effects.pdf))
 
 * **The semantic marriage of monads and effects (extended abstract)** (Unpublished, 2014)  
@@ -1105,6 +1219,7 @@ in various programming languages.
   by Edwin Brady  
   ([doi](https://doi.org/10.1145/2500365.2500581))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/Brady13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/Brady13.html?view=bibtex))
   ([pdf](https://www.type-driven.org.uk/edwinb/papers/effects.pdf))
 
 * **The constrained-monad problem** (ICFP 2013)  
@@ -1115,6 +1230,7 @@ in various programming languages.
   by Ohad Kammar, Sam Lindley and Nicolas Oury  
   ([doi](https://doi.org/10.1145/2500365.2500590))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/KammarLO13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/KammarLO13.html?view=bibtex))
   ([pdf](http://homepages.inf.ed.ac.uk/slindley/papers/handlers.pdf))
   ([GitHub](https://github.com/slindley/effect-handlers))
 
@@ -1122,12 +1238,14 @@ in various programming languages.
   by Oleg Kiselyov, Amr Sabry and Cameron Swords  
   ([doi](https://doi.org/10.1145/2503778.2503791))
   ([dblp](https://dblp.uni-trier.de/rec/conf/haskell/KiselyovSS13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/haskell/KiselyovSS13.html?view=bibtex))
   ([pdf](https://www.cs.indiana.edu/~sabry/papers/exteff.pdf))
 
 * **JavaUI: Effects for UI Object Access** (ECOOP 2013)  
   by Colin S. Gordon, Werner Dietl, Michael D. Ernst and Dan Grossman  
   ([doi](http://dx.doi.org/10.1007/978-3-642-39038-8_8))
   ([dblp](https://dblp.uni-trier.de/rec/conf/ecoop/GordonDEG13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/ecoop/GordonDEG13.html?view=bibtex))
   ([pdf](https://www.cs.drexel.edu/~csgordon/papers/ecoop13.pdf))
 
 * **Handling algebraic effects** (LMCS 2013)  
@@ -1141,6 +1259,7 @@ in various programming languages.
   by Danel Ahman and Sam Staton  
   ([doi](https://doi.org/10.1016/j.entcs.2013.09.007))
   ([dblp](https://dblp.uni-trier.de/rec/journals/entcs/AhmanS13.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/entcs/AhmanS13.html?view=bibtex))
   ([pdf](https://danel.ahman.ee/papers/mfps13.pdf))
 
 * **The Sequential Semantics of Producer Effect Systems** (POPL 2013)  
@@ -1179,6 +1298,7 @@ in various programming languages.
   by Jeremy Gibbons and Ralf Hinze
   ([doi](https://doi.org/10.1145/2034773.2034777))
   ([dblp](https://dblp.uni-trier.de/rec/conf/icfp/GibbonsH11.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/conf/icfp/GibbonsH11.html?view=bibtex))
 
 ### 2010
 
@@ -1186,6 +1306,7 @@ in various programming languages.
   by Mauro Jaskelioff and Eugenio Moggi
   ([doi](https://doi.org/10.1016/j.tcs.2010.09.011))
   ([dblp](https://dblp.uni-trier.de/rec/journals/tcs/JaskelioffM10.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/journals/tcs/JaskelioffM10.html?view=bibtex))
 
 * **The Operational Monad Tutorial** (The Monad Reader, 2010)  
   by Heinrich Apfelmus
@@ -1427,6 +1548,7 @@ in various programming languages.
 * **Design and Implementation of Effect Handlers for Object-Oriented Programming Languages** (PhD Dissertation, University of Tübingen)  
   by Jonathan Immanuel Brachthäuser  
   ([dblp](https://dblp.uni-trier.de/rec/phd/dnb/Brachthauser20.html))
+  ([bibtex](https://dblp.uni-trier.de/rec/phd/dnb/Brachthauser20.html?view=bibtex))
 
 ### 2019
 


### PR DESCRIPTION
For the purpose of writing a survey paper, I've started collecting papers on handlers from DBLP. I plan to add interesting missing papers later on, but first, I've done slight white-space changes and added DOIs and DBLP links for most of the papers from 2010 onwards.
