### PR TITLE
add Heftia library

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ in various programming languages.
   ([GitHub](https://github.com/robrix/fused-effects))
 
 * **Heftia**: a library for semantically-sound higher‑order algebraic effects and handlers in Haskell  
-  by Riyo  
+  by Riyo Yamada  
   ([GitHub](https://github.com/sayo-hs/heftia))
   ([hackage](https://hackage.haskell.org/package/heftia-effects))
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ in various programming languages.
   ([hackage](https://hackage.haskell.org/package/fused-effects))
   ([GitHub](https://github.com/robrix/fused-effects))
 
+* **Heftia**: a library for semantically-sound higher‑order algebraic effects and handlers in Haskell  
+  by Riyo  
+  ([GitHub](https://github.com/sayo-hs/heftia))
+  ([hackage](https://hackage.haskell.org/package/heftia-effects))
+
 * **Helium**: a functional programming language with effect handlers and an ML-like module system  
   by Dariusz Biernacki, Maciej Piróg, Piotr Polesiuk, and Filip Sieczkowski  
   ([BitBucket](https://bitbucket.org/pl-uwr/helium))


### PR DESCRIPTION
This PR adds the Heftia library to the Software list.

Heftia is a Haskell library based on the theories presented in "Hefty Algebras" (POPL 2023) and "A Framework for Higher-Order Effects & Handlers" (SCP 2024).